### PR TITLE
[codex] support model definition ids

### DIFF
--- a/config/models/openai/gpt-4o-mini.yaml
+++ b/config/models/openai/gpt-4o-mini.yaml
@@ -1,3 +1,4 @@
+id: openai/gpt-4o-mini/default
 code: gpt-4o-mini
 provider: openai
 providerModelCode: gpt-4o-mini

--- a/config/models/openai/gpt-4o.yaml
+++ b/config/models/openai/gpt-4o.yaml
@@ -1,3 +1,4 @@
+id: openai/gpt-4o/default
 code: gpt-4o
 provider: openai
 providerModelCode: gpt-4o

--- a/config/models/openrouter/openai-gpt-4o-mini.yaml
+++ b/config/models/openrouter/openai-gpt-4o-mini.yaml
@@ -1,3 +1,4 @@
+id: openrouter/openai-gpt-4o-mini/default
 code: gpt-4o-mini-openrouter
 provider: openrouter
 providerModelCode: openai/gpt-4o-mini

--- a/config/models/vertex-anthropic/claude-3-opus.yaml
+++ b/config/models/vertex-anthropic/claude-3-opus.yaml
@@ -1,3 +1,4 @@
+id: vertex_anthropic/claude-3-opus-20240229/default
 code: claude-3-opus
 provider: vertex_anthropic
 providerModelCode: claude-3-opus-20240229

--- a/dist/src/cli/list-values.js
+++ b/dist/src/cli/list-values.js
@@ -16,7 +16,7 @@ const sortUnique = (values) => Array.from(new Set(values)).sort((a, b) => a.loca
 const readMarkdownFrontMatter = (filePath) => extractFrontMatterAndTemplate(fs.readFileSync(filePath, 'utf-8')).templateConfig;
 const formatSection = (title, values, emptyMessage) => [`${title}:`, ...(values.length > 0 ? values.map(value => `  ${value}`) : [`  ${emptyMessage}`])].join('\n');
 export const listAvailableModels = () => getFileBackedModelRegistry()
-    .activeModels.map(model => JSON.stringify({ provider: model.provider, model: model.providerModelCode }))
+    .activeModels.map(model => JSON.stringify({ id: model.id }))
     .sort((a, b) => a.localeCompare(b));
 export const listAvailableTags = () => sortUnique(listAllMdFiles(envConfig.AI_TESTER_TESTS_DIR).flatMap(file => TestListConfigSchema.parse(readMarkdownFrontMatter(file)).tags ?? []));
 export const listAvailablePromptCodes = () => sortUnique(listAllMdFiles(envConfig.AI_TESTER_PROMPTS_DIR).flatMap(file => {

--- a/dist/src/config/config-file.js
+++ b/dist/src/config/config-file.js
@@ -12,8 +12,7 @@ export const TemperatureSchema = z.number().min(0).max(1).default(DEFAULT_TEMPER
 export const RequiredTagsSchema = z.array(z.string()).default([]);
 export const ProhibitedTagsSchema = z.array(z.string()).default(DEFAULT_PROHIBITED_TAGS);
 export const ConfiguredModelsSchema = z.array(z.object({
-    provider: z.string(),
-    model: z.string(),
+    id: z.string().min(1),
     /** Tags to include in this session for this model only (not provided means no restrictions) */
     requiredTags: RequiredTagsSchema.optional(),
     /** Tags to exclude from this session for this model only (not provided means no restrictions) */
@@ -23,14 +22,13 @@ export const ConfiguredModelsSchema = z.array(z.object({
 })).superRefine((models, ctx) => {
     const seen = new Set();
     for (const model of models) {
-        const key = `${model.provider}:${model.model}`;
-        if (seen.has(key)) {
+        if (seen.has(model.id)) {
             ctx.addIssue({
                 code: z.ZodIssueCode.custom,
-                message: `Duplicate configured model reference: ${key}`,
+                message: `Duplicate configured model reference: ${model.id}`,
             });
         }
-        seen.add(key);
+        seen.add(model.id);
     }
 });
 export const AnalysisQuerySchema = z.object({

--- a/dist/src/config/model-registry.js
+++ b/dist/src/config/model-registry.js
@@ -68,7 +68,16 @@ const RuntimeOptionsOverrideSchema = z.object({
     providerOptions: z.record(JsonValueSchema).optional(),
     thinking: ThinkingConfigSchema,
 });
-export const ModelDefinitionSchema = z.object({
+const VERSIONED_MODEL_PROPERTY_PREFIXES = [
+    'extraIdentifier',
+    'providerOptions',
+    'thinking',
+    'candidateOverrides',
+    'evaluatorOverrides',
+];
+export const ModelDefinitionSchema = z
+    .object({
+    id: z.string().min(1).optional(),
     code: z.string(),
     provider: z.string(),
     providerModelCode: z.string(),
@@ -84,6 +93,7 @@ export const ModelDefinitionSchema = z.object({
     capabilities: ModelCapabilitiesSchema.optional(),
     candidateOverrides: RuntimeOptionsOverrideSchema.optional(),
     evaluatorOverrides: RuntimeOptionsOverrideSchema.optional(),
+    uniqueProperties: z.array(z.string().min(1)).default([]),
     costs: z
         .array(CostDefinitionSchema)
         .default([])
@@ -105,7 +115,11 @@ export const ModelDefinitionSchema = z.object({
             seen.add(cost.validFrom);
         }
     }),
-});
+})
+    .transform(model => ({
+    ...model,
+    id: model.id ?? `${model.provider}/${model.providerModelCode}`,
+}));
 const getYamlFilesOrThrow = (basePath, label) => {
     if (!fs.existsSync(basePath)) {
         throw new Error(`${label} directory not found: ${basePath}`);
@@ -120,25 +134,6 @@ const getModelReferenceKey = (model) => `${model.provider}:${model.providerModel
 export const getModelRuntimeOptions = (model) => ({
     providerOptions: model.providerOptions,
     thinking: model.thinking ?? null,
-});
-export const getRoleAwareModelRuntimeOptions = (model) => ({
-    ...getModelRuntimeOptions(model),
-    ...(model.candidateOverrides !== undefined
-        ? {
-            candidateOverrides: {
-                providerOptions: model.candidateOverrides.providerOptions ?? {},
-                thinking: model.candidateOverrides.thinking ?? null,
-            },
-        }
-        : {}),
-    ...(model.evaluatorOverrides !== undefined
-        ? {
-            evaluatorOverrides: {
-                providerOptions: model.evaluatorOverrides.providerOptions ?? {},
-                thinking: model.evaluatorOverrides.thinking ?? null,
-            },
-        }
-        : {}),
 });
 export const getEffectiveModelRuntimeOptions = (model, type) => {
     const overrides = type === 'candidate' ? model.candidateOverrides : model.evaluatorOverrides;
@@ -155,26 +150,83 @@ export const getEffectiveModelRuntimeOptions = (model, type) => {
             : undefined,
     };
 };
-export const getModelRuntimeOptionsJson = (model) => stableJsonStringify(getRoleAwareModelRuntimeOptions(model));
-const getModelIdentityKey = (model) => `${model.provider}:${model.providerModelCode}:${model.extraIdentifier ?? ''}:${getModelRuntimeOptionsJson(model)}`;
+export const getModelRuntimeOptionsJson = (model, role) => {
+    const options = getEffectiveModelRuntimeOptions(model, role);
+    return stableJsonStringify({
+        providerOptions: options.providerOptions,
+        thinking: options.thinking ?? null,
+    });
+};
+export const getModelRuntimeIdentityKeyFromParts = ({ provider, providerModelCode, extraIdentifier, runtimeOptionsJson, }) => `${provider}:${providerModelCode}:${extraIdentifier ?? ''}:${runtimeOptionsJson}`;
+export const getModelRuntimeIdentityKey = (model, role) => getModelRuntimeIdentityKeyFromParts({
+    provider: model.provider,
+    providerModelCode: model.providerModelCode,
+    extraIdentifier: model.extraIdentifier,
+    runtimeOptionsJson: getModelRuntimeOptionsJson(model, role),
+});
+export const getModelRuntimeIdentityKeys = (model) => Array.from(new Set(['candidate', 'evaluator'].map(role => getModelRuntimeIdentityKey(model, role))));
+export const getModelRuntimeIdentities = (model) => {
+    const identities = new Map();
+    for (const role of ['candidate', 'evaluator']) {
+        const runtimeOptionsJson = getModelRuntimeOptionsJson(model, role);
+        const key = getModelRuntimeIdentityKeyFromParts({
+            provider: model.provider,
+            providerModelCode: model.providerModelCode,
+            extraIdentifier: model.extraIdentifier,
+            runtimeOptionsJson,
+        });
+        identities.set(key, { key, runtimeOptionsJson });
+    }
+    return Array.from(identities.values());
+};
+const getModelPropertyValue = (model, propertyPath) => {
+    const pathParts = propertyPath.split('.');
+    let value = model;
+    for (const pathPart of pathParts) {
+        if (value === null || typeof value !== 'object' || !Object.prototype.hasOwnProperty.call(value, pathPart)) {
+            return undefined;
+        }
+        value = value[pathPart];
+    }
+    return value;
+};
+const validateUniqueProperties = (model) => {
+    for (const propertyPath of model.uniqueProperties) {
+        if (!VERSIONED_MODEL_PROPERTY_PREFIXES.some(prefix => propertyPath === prefix || propertyPath.startsWith(`${prefix}.`))) {
+            throw new Error(`Model ${model.id} declares unsupported uniqueProperties path ${propertyPath}. Unique properties must reference versioned runtime settings: ${VERSIONED_MODEL_PROPERTY_PREFIXES.join(', ')}.`);
+        }
+        if (getModelPropertyValue(model, propertyPath) === undefined) {
+            throw new Error(`Model ${model.id} declares uniqueProperties path ${propertyPath}, but that value is not set.`);
+        }
+    }
+};
+const getUniquePropertiesKey = (model) => stableJsonStringify(Object.fromEntries(model.uniqueProperties.map(propertyPath => [propertyPath, getModelPropertyValue(model, propertyPath)])));
 const getActiveModels = (models) => {
     const groupedModels = new Map();
+    const activeModels = [];
     for (const model of models) {
         if (!model.active)
             continue;
         const key = getModelReferenceKey(model);
         groupedModels.set(key, [...(groupedModels.get(key) ?? []), model]);
+        activeModels.push(model);
     }
-    const activeModels = [];
     for (const [reference, variants] of groupedModels) {
         if (variants.length === 1) {
-            activeModels.push(variants[0]);
             continue;
         }
-        const details = variants
-            .map(model => `${model.code}${model.extraIdentifier ? ` (extraIdentifier: ${model.extraIdentifier})` : ''}`)
-            .join(', ');
-        throw new Error(`Conflicting active model variants for ${reference}: ${details}. Set active: false on all but one YAML entry for this provider/model code combination.`);
+        const variantsWithoutUniqueProperties = variants.filter(model => model.uniqueProperties.length === 0);
+        if (variantsWithoutUniqueProperties.length > 0) {
+            throw new Error(`Active model variants for ${reference} must declare uniqueProperties: ${variantsWithoutUniqueProperties.map(model => model.id).join(', ')}.`);
+        }
+        const uniquePropertyKeys = new Set();
+        for (const variant of variants) {
+            const key = getUniquePropertiesKey(variant);
+            if (uniquePropertyKeys.has(key)) {
+                throw new Error(`Active model variants for ${reference} do not have distinct uniqueProperties values: ${variants.map(model => model.id).join(', ')}.`);
+            }
+            uniquePropertyKeys.add(key);
+        }
     }
     return activeModels;
 };
@@ -192,16 +244,25 @@ export const loadProviderDefinitions = () => {
 export const loadModelDefinitions = (providersByCode) => {
     const providerMap = providersByCode ?? new Map(loadProviderDefinitions().map(provider => [provider.code, provider]));
     const models = getYamlFilesOrThrow(envConfig.AI_TESTER_MODELS_DIR, 'Model registry').map(file => readYamlFile(file, ModelDefinitionSchema));
-    const seen = new Set();
+    const seenRuntimeIdentities = new Set();
+    const seenIds = new Set();
     for (const model of models) {
         if (!providerMap.has(model.provider)) {
             throw new Error(`Model ${model.code} references missing provider ${model.provider}. Create the provider YAML file first.`);
         }
-        const key = getModelIdentityKey(model);
-        if (seen.has(key)) {
-            throw new Error(`Duplicate runtime model identity found in YAML files: ${key}. Each provider/providerModelCode/extraIdentifier combination must map to exactly one YAML entry.`);
+        if (model.active) {
+            if (seenIds.has(model.id)) {
+                throw new Error(`Duplicate active model id found in YAML files: ${model.id}`);
+            }
+            seenIds.add(model.id);
         }
-        seen.add(key);
+        validateUniqueProperties(model);
+        for (const key of getModelRuntimeIdentityKeys(model)) {
+            if (seenRuntimeIdentities.has(key)) {
+                throw new Error(`Duplicate runtime model identity found in YAML files: ${key}. Each provider/providerModelCode/extraIdentifier/runtime-options combination must map to exactly one YAML entry.`);
+            }
+            seenRuntimeIdentities.add(key);
+        }
     }
     return models;
 };
@@ -210,13 +271,15 @@ export const loadFileBackedModelRegistry = () => {
     const providersByCode = new Map(providers.map(provider => [provider.code, provider]));
     const models = loadModelDefinitions(providersByCode);
     const activeModels = getActiveModels(models);
-    const modelsByReference = new Map(activeModels.map(model => [getModelReferenceKey(model), model]));
+    const modelsById = new Map(activeModels.map(model => [model.id, model]));
+    const modelsByRuntimeIdentity = new Map(activeModels.flatMap(model => getModelRuntimeIdentityKeys(model).map(key => [key, model])));
     return {
         providers,
         providersByCode,
         models,
         activeModels,
-        modelsByReference,
+        modelsById,
+        modelsByRuntimeIdentity,
     };
 };
 let cachedRegistry;
@@ -232,7 +295,7 @@ export const filterConfiguredModels = (models, context, registry = getFileBacked
     const availableModels = [];
     const missingModels = [];
     for (const model of models) {
-        if (registry.modelsByReference.has(`${model.provider}:${model.model}`)) {
+        if (registry.modelsById.has(model.id)) {
             availableModels.push(model);
         }
         else {
@@ -241,9 +304,7 @@ export const filterConfiguredModels = (models, context, registry = getFileBacked
     }
     if (missingModels.length > 0 && !warnedContexts.has(context)) {
         warnedContexts.add(context);
-        console.warn(`Skipping unavailable models in ${context}: ${missingModels
-            .map(model => `${model.provider}:${model.model}`)
-            .join(', ')}`);
+        console.warn(`Skipping unavailable models in ${context}: ${missingModels.map(model => model.id).join(', ')}`);
     }
     return {
         availableModels,

--- a/dist/src/main/evaluations.js
+++ b/dist/src/main/evaluations.js
@@ -1,7 +1,7 @@
 /**
  * This module is responsible for running all session evaluations that have not been run yet.
  */
-import { and, or, eq, ne, inArray, sql, lt, countDistinct, aliasedTable } from 'drizzle-orm';
+import { and, or, eq, not, inArray, sql, lt, countDistinct, aliasedTable } from 'drizzle-orm';
 import { generateText, Output } from 'ai';
 import z from 'zod';
 import { schema } from '../database/schema.js';
@@ -9,6 +9,7 @@ import { getSectionsFromMarkdownContent, sectionsToAiMessages } from '../utils/m
 import { getRequiredLanguageModelTokenUsage, getTrimmedReasoningText } from '../utils/ai-sdk.js';
 import { getModelCapabilityStatus, logCapabilitySkip, warnIfCapabilitiesUndeclared, } from './capabilities.js';
 import { refreshEvaluationTokenLimitState } from './token-limits.js';
+import { getConfiguredModelDefinition, getModelDefinitionForVersion, getModelVersionLabel, modelVersionMatchesDefinition, } from './model-definition-filters.js';
 const evalSchema = z.object({
     // Note: `.nullable()` is not supported by some providers (like Vertex AI) as it generates an unsupported `anyOf` schema
     feedback: z
@@ -33,12 +34,20 @@ const getMissingEvaluations = async (db, testsConfig, registry, envConfig, { log
     }
     // we query the DB to get all missing evaluations not yet run
     const { testVersions, prompts, testToTagRels, testEvaluationInstructionsVersions, testToEvaluationInstructionsRels, tags, sessions, modelVersions, providers, models, promptVersions, sessionEvaluations, } = schema;
-    const modelConfigsWithTemperature = testsConfig.evaluators.filter(evaluator => evaluator.temperature !== undefined);
-    const modelConfigsWithTags = testsConfig.evaluators.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0);
-    const modelConfigsWithProhibitedTags = testsConfig.evaluators.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0);
-    const candidateModelConfigsWithTemperature = testsConfig.candidates.filter(candidate => candidate.temperature !== undefined);
-    const candidateModelConfigsWithTags = testsConfig.candidates.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0);
-    const candidateModelConfigsWithProhibitedTags = testsConfig.candidates.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0);
+    const evaluatorsWithDefinitions = testsConfig.evaluators.map(evaluator => ({
+        ...evaluator,
+        modelDefinition: getConfiguredModelDefinition(registry, evaluator),
+    }));
+    const candidatesWithDefinitions = testsConfig.candidates.map(candidate => ({
+        ...candidate,
+        modelDefinition: getConfiguredModelDefinition(registry, candidate),
+    }));
+    const modelConfigsWithTemperature = evaluatorsWithDefinitions.filter(evaluator => evaluator.temperature !== undefined);
+    const modelConfigsWithTags = evaluatorsWithDefinitions.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0);
+    const modelConfigsWithProhibitedTags = evaluatorsWithDefinitions.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0);
+    const candidateModelConfigsWithTemperature = candidatesWithDefinitions.filter(candidate => candidate.temperature !== undefined);
+    const candidateModelConfigsWithTags = candidatesWithDefinitions.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0);
+    const candidateModelConfigsWithProhibitedTags = candidatesWithDefinitions.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0);
     const candidateModelVersionAlias = aliasedTable(modelVersions, 'candidate_model_version_alias');
     const candidateProviderAlias = aliasedTable(providers, 'candidate_provider_alias');
     const candidateModelAlias = aliasedTable(models, 'candidate_model_alias');
@@ -48,6 +57,8 @@ const getMissingEvaluations = async (db, testsConfig, registry, envConfig, { log
         .select({
         modelVersionId: modelVersions.id,
         modelVersionCode: modelVersions.providerModelCode,
+        modelVersionExtraIdentifier: modelVersions.extraIdentifier,
+        modelVersionRuntimeOptionsJson: modelVersions.runtimeOptionsJson,
         providerCode: providers.code,
         testVersionId: testVersions.id,
         testContent: testVersions.content,
@@ -61,20 +72,19 @@ const getMissingEvaluations = async (db, testsConfig, registry, envConfig, { log
     })
         .from(modelVersions)
         .innerJoin(evaluatorModelAlias, and(eq(evaluatorModelAlias.id, modelVersions.modelId), eq(evaluatorModelAlias.active, true), eq(modelVersions.active, true)))
-        .innerJoin(providers, and(eq(providers.id, modelVersions.providerId), eq(providers.active, true), or(...testsConfig.evaluators.map(({ provider, model }) => and(eq(providers.code, provider), eq(modelVersions.providerModelCode, model))))))
+        .innerJoin(providers, and(eq(providers.id, modelVersions.providerId), eq(providers.active, true), or(...evaluatorsWithDefinitions.map(evaluator => modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator')))))
         // always true to fetch all possible session combinations (we will filter later - cross joins aren't supported in drizzle-orm as of now)
         .innerJoin(sessions, and(eq(sessions.id, sessions.id), eq(sessions.active, true), candidateModelConfigsWithTemperature.length > 0
         ? sql `${sessions.temperature} = CASE
 							${sql.join(candidateModelConfigsWithTemperature.map(candidate => sql `WHEN
-											${eq(candidateModelVersionAlias.providerModelCode, candidate.model)}
-											AND ${eq(candidateProviderAlias.code, candidate.provider)}
+											${modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate')}
 											THEN ${candidate.temperature}`))}
 							ELSE ${testsConfig.candidatesTemperature}
 						END`
         : eq(sessions.temperature, testsConfig.candidatesTemperature)))
         .innerJoin(candidateModelVersionAlias, eq(candidateModelVersionAlias.id, sessions.modelVersionId))
         .innerJoin(candidateModelAlias, and(eq(candidateModelAlias.id, candidateModelVersionAlias.modelId), eq(candidateModelAlias.active, true), eq(candidateModelVersionAlias.active, true)))
-        .innerJoin(candidateProviderAlias, and(eq(candidateProviderAlias.id, candidateModelVersionAlias.providerId), eq(candidateProviderAlias.active, true), or(...testsConfig.candidates.map(({ provider, model }) => and(eq(candidateProviderAlias.code, provider), eq(candidateModelVersionAlias.providerModelCode, model))))))
+        .innerJoin(candidateProviderAlias, and(eq(candidateProviderAlias.id, candidateModelVersionAlias.providerId), eq(candidateProviderAlias.active, true), or(...candidatesWithDefinitions.map(candidate => modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate')))))
         .innerJoin(prompts, eq(prompts.code, '_evaluator_default'))
         .innerJoin(promptVersions, and(eq(promptVersions.promptId, prompts.id), eq(promptVersions.active, true)))
         // we add the evaluation prompt version to the query
@@ -83,8 +93,7 @@ const getMissingEvaluations = async (db, testsConfig, registry, envConfig, { log
         .leftJoin(sessionEvaluations, and(eq(sessionEvaluations.sessionId, sessions.id), eq(sessionEvaluations.modelVersionId, modelVersions.id), eq(sessionEvaluations.evaluationPromptVersionId, promptVersions.id), eq(sessionEvaluations.testEvaluationInstructionsVersionId, testEvaluationInstructionsVersions.id), eq(sessionEvaluations.active, true), modelConfigsWithTemperature.length > 0
         ? sql `${sessionEvaluations.temperature} = CASE
 								${sql.join(modelConfigsWithTemperature.map(evaluator => sql `WHEN
-												${eq(modelVersions.providerModelCode, evaluator.model)}
-												AND ${eq(providers.code, evaluator.provider)}
+												${modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator')}
 												THEN ${evaluator.temperature}`))}
 								ELSE ${testsConfig.evaluatorsTemperature}
 							END`
@@ -114,19 +123,19 @@ const getMissingEvaluations = async (db, testsConfig, registry, envConfig, { log
             : []),
         // ensure we have all required tags for each model
         ...(modelConfigsWithTags.length > 0
-            ? modelConfigsWithTags.map(evaluator => sql `sum(CASE WHEN ${or(ne(modelVersions.providerModelCode, evaluator.model), ne(providers.code, evaluator.provider), inArray(tags.name, evaluator.requiredTags))} THEN 1 ELSE 0 END) > 0`)
+            ? modelConfigsWithTags.map(evaluator => sql `sum(CASE WHEN ${or(not(modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator')), inArray(tags.name, evaluator.requiredTags))} THEN 1 ELSE 0 END) > 0`)
             : []),
         // ensure we don't have any prohibited tags for each model
         ...(modelConfigsWithProhibitedTags.length > 0
-            ? modelConfigsWithProhibitedTags.map(evaluator => sql `sum(CASE WHEN ${and(eq(modelVersions.providerModelCode, evaluator.model), eq(providers.code, evaluator.provider), inArray(tags.name, evaluator.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
+            ? modelConfigsWithProhibitedTags.map(evaluator => sql `sum(CASE WHEN ${and(modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator'), inArray(tags.name, evaluator.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
             : []),
         // ensure we have all required tags for each candidate model
         ...(candidateModelConfigsWithTags.length > 0
-            ? candidateModelConfigsWithTags.map(candidate => sql `sum(CASE WHEN ${or(ne(candidateModelVersionAlias.providerModelCode, candidate.model), ne(candidateProviderAlias.code, candidate.provider), inArray(tags.name, candidate.requiredTags))} THEN 1 ELSE 0 END) > 0`)
+            ? candidateModelConfigsWithTags.map(candidate => sql `sum(CASE WHEN ${or(not(modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate')), inArray(tags.name, candidate.requiredTags))} THEN 1 ELSE 0 END) > 0`)
             : []),
         // ensure we don't have any prohibited tags for each candidate model
         ...(candidateModelConfigsWithProhibitedTags.length > 0
-            ? candidateModelConfigsWithProhibitedTags.map(candidate => sql `sum(CASE WHEN ${and(eq(candidateModelVersionAlias.providerModelCode, candidate.model), eq(candidateProviderAlias.code, candidate.provider), inArray(tags.name, candidate.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
+            ? candidateModelConfigsWithProhibitedTags.map(candidate => sql `sum(CASE WHEN ${and(modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate'), inArray(tags.name, candidate.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
             : []),
     ]))
         // ordering by model id is important as Ollama and other local models have some initial load time to consider
@@ -138,8 +147,8 @@ const getMissingEvaluations = async (db, testsConfig, registry, envConfig, { log
         output: ['structured'],
     };
     return missingEvaluations.filter(evaluation => {
-        const modelReference = `${evaluation.providerCode}:${evaluation.modelVersionCode}`;
-        const modelDefinition = registry.modelsByReference.get(modelReference);
+        const modelReference = getModelVersionLabel(registry, evaluation);
+        const modelDefinition = getModelDefinitionForVersion(registry, evaluation);
         if (log)
             warnIfCapabilitiesUndeclared(modelDefinition, modelReference, warnedModelReferences);
         const capabilityStatus = getModelCapabilityStatus(modelDefinition, requirements);
@@ -157,7 +166,7 @@ export const runAllEvaluationsWithDeps = async ({ db, testsConfig, registry, con
     const { sessionEvaluations } = schema;
     const missingEvaluations = await getMissingEvaluations(db, testsConfig, registry, envConfig);
     const modelConfigsWithTemperature = testsConfig.evaluators.filter(evaluator => evaluator.temperature !== undefined);
-    const modelsWithTemperatures = new Map(modelConfigsWithTemperature.map(({ provider, model, temperature }) => [`${provider}:${model}`, temperature]));
+    const modelsWithTemperatures = new Map(modelConfigsWithTemperature.map(({ id, temperature }) => [id, temperature]));
     // The total number of missing evaluations needs to account for the number of judgments
     const totalMissingEvaluations = missingEvaluations.reduce((acc, evaluation) => acc + (testsConfig.evaluationsPerEvaluator - evaluation.evaluationsCount), 0);
     if (totalMissingEvaluations === 0) {
@@ -174,10 +183,9 @@ export const runAllEvaluationsWithDeps = async ({ db, testsConfig, registry, con
         const provider = getProvider(evaluation.providerCode);
         if (!provider)
             throw new Error(`Provider ${evaluation.providerCode} not found`);
-        const modelDefinition = registry.modelsByReference.get(`${evaluation.providerCode}:${evaluation.modelVersionCode}`);
+        const modelDefinition = getModelDefinitionForVersion(registry, evaluation);
         const model = wrapModel(provider(evaluation.modelVersionCode), 'evaluator', modelDefinition);
-        const temperature = modelsWithTemperatures.get(`${evaluation.providerCode}:${evaluation.modelVersionCode}`) ??
-            testsConfig.evaluatorsTemperature;
+        const temperature = (modelDefinition ? modelsWithTemperatures.get(modelDefinition.id) : undefined) ?? testsConfig.evaluatorsTemperature;
         // We extract the array of messages
         const sections = getSectionsFromMarkdownContent(evaluation.evalPromptContent);
         // const testSections = parseMarkdownContent(evaluation.testContent)

--- a/dist/src/main/model-definition-filters.js
+++ b/dist/src/main/model-definition-filters.js
@@ -1,0 +1,26 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { getModelRuntimeIdentityKeyFromParts, getModelRuntimeOptionsJson, } from '../config/model-registry.js';
+export const getConfiguredModelDefinition = (registry, configuredModel) => {
+    const modelDefinition = registry.modelsById.get(configuredModel.id);
+    if (!modelDefinition) {
+        throw new Error(`Configured model ${configuredModel.id} is not available in the active model registry.`);
+    }
+    return modelDefinition;
+};
+export const getConfiguredModelDefinitions = (registry, configuredModels) => configuredModels.map(configuredModel => getConfiguredModelDefinition(registry, configuredModel));
+export const modelVersionMatchesDefinition = (providerTable, modelVersionTable, modelDefinition, role) => and(eq(providerTable.code, modelDefinition.provider), eq(modelVersionTable.providerModelCode, modelDefinition.providerModelCode), eq(modelVersionTable.runtimeOptionsJson, getModelRuntimeOptionsJson(modelDefinition, role)), modelDefinition.extraIdentifier
+    ? eq(modelVersionTable.extraIdentifier, modelDefinition.extraIdentifier)
+    : isNull(modelVersionTable.extraIdentifier));
+export const getModelDefinitionForVersion = (registry, row) => registry.modelsByRuntimeIdentity.get(getModelRuntimeIdentityKeyFromParts({
+    provider: row.providerCode,
+    providerModelCode: row.modelVersionCode,
+    extraIdentifier: row.modelVersionExtraIdentifier,
+    runtimeOptionsJson: row.modelVersionRuntimeOptionsJson,
+}));
+export const getModelVersionLabel = (registry, row) => getModelDefinitionForVersion(registry, row)?.id ??
+    getModelRuntimeIdentityKeyFromParts({
+        provider: row.providerCode,
+        providerModelCode: row.modelVersionCode,
+        extraIdentifier: row.modelVersionExtraIdentifier,
+        runtimeOptionsJson: row.modelVersionRuntimeOptionsJson,
+    });

--- a/dist/src/main/providers.js
+++ b/dist/src/main/providers.js
@@ -4,9 +4,8 @@ import { providers } from '../database/schema/providers.js';
 import { models, modelVersions } from '../database/schema/models.js';
 import { currencies, modelCosts } from '../database/schema/costs.js';
 import { sessionEvaluations, sessions } from '../database/schema/sessions.js';
-import { clearFileBackedModelRegistryCache, getModelRuntimeOptionsJson, loadFileBackedModelRegistry, } from '../config/model-registry.js';
+import { clearFileBackedModelRegistryCache, getModelRuntimeIdentityKeys, getModelRuntimeIdentities, loadFileBackedModelRegistry, } from '../config/model-registry.js';
 import { isCurrencyRegistryConfigured, validateCurrencyRegistryReferences } from '../config/currency-registry.js';
-const getModelIdentityKey = (model) => `${model.provider}:${model.providerModelCode}:${model.extraIdentifier ?? ''}:${getModelRuntimeOptionsJson(model)}`;
 const setActiveByIds = async (tx, table, ids) => {
     await tx.update(table).set({ active: false });
     if (ids.length > 0) {
@@ -151,9 +150,9 @@ const upsertModel = async (tx, modelConfig) => {
     }
     return model;
 };
-const upsertModelVersion = async (tx, providerId, modelId, modelConfig) => {
+const upsertModelVersion = async (tx, providerId, modelId, modelConfig, runtimeOptionsJson) => {
     let modelVersion = await tx.query.modelVersions.findFirst({
-        where: and(eq(modelVersions.providerId, providerId), eq(modelVersions.providerModelCode, modelConfig.providerModelCode), eq(modelVersions.runtimeOptionsJson, getModelRuntimeOptionsJson(modelConfig)), modelConfig.extraIdentifier
+        where: and(eq(modelVersions.providerId, providerId), eq(modelVersions.providerModelCode, modelConfig.providerModelCode), eq(modelVersions.runtimeOptionsJson, runtimeOptionsJson), modelConfig.extraIdentifier
             ? eq(modelVersions.extraIdentifier, modelConfig.extraIdentifier)
             : isNull(modelVersions.extraIdentifier)),
     });
@@ -175,7 +174,7 @@ const upsertModelVersion = async (tx, providerId, modelId, modelConfig) => {
             providerId,
             providerModelCode: modelConfig.providerModelCode,
             extraIdentifier: modelConfig.extraIdentifier,
-            runtimeOptionsJson: getModelRuntimeOptionsJson(modelConfig),
+            runtimeOptionsJson,
             active: true,
         })
             .returning();
@@ -205,17 +204,23 @@ const syncRegistryToDb = async (registry) => {
             }
         }
         const activeModelVersionIds = new Set();
-        const activeModelIdentityKeys = new Set(registry.activeModels.map(model => getModelIdentityKey(model)));
+        const syncedCostModelVersionIds = new Set();
+        const activeModelIdentityKeys = new Set(registry.activeModels.flatMap(model => getModelRuntimeIdentityKeys(model)));
         for (const modelConfig of registry.models) {
             const provider = providersByCode.get(modelConfig.provider);
             const model = modelsByCode.get(modelConfig.code);
             if (!provider || !model) {
                 throw new Error(`Failed to resolve registry entry ${modelConfig.provider}:${modelConfig.providerModelCode}`);
             }
-            const modelVersion = await upsertModelVersion(tx, provider.id, model.id, modelConfig);
-            if (activeModelIdentityKeys.has(getModelIdentityKey(modelConfig))) {
-                activeModelVersionIds.add(modelVersion.id);
-                await syncModelCostsFromYaml(tx, modelVersion.id, modelConfig);
+            for (const identity of getModelRuntimeIdentities(modelConfig)) {
+                const modelVersion = await upsertModelVersion(tx, provider.id, model.id, modelConfig, identity.runtimeOptionsJson);
+                if (activeModelIdentityKeys.has(identity.key)) {
+                    activeModelVersionIds.add(modelVersion.id);
+                    if (!syncedCostModelVersionIds.has(modelVersion.id)) {
+                        await syncModelCostsFromYaml(tx, modelVersion.id, modelConfig);
+                        syncedCostModelVersionIds.add(modelVersion.id);
+                    }
+                }
             }
         }
         await setActiveByIds(tx, providers, activeProviderIds);

--- a/dist/src/main/sessions.js
+++ b/dist/src/main/sessions.js
@@ -1,7 +1,7 @@
 /**
  * This module is responsible for running all test sessions that have not been run yet.
  */
-import { and, or, eq, ne, inArray, sql, lt, countDistinct } from 'drizzle-orm';
+import { and, or, eq, not, inArray, sql, lt, countDistinct } from 'drizzle-orm';
 import { generateText, jsonSchema, Output, } from 'ai';
 import { schema } from '../database/schema.js';
 import { getSectionsFromMarkdownContent, sectionsToAiMessages, getReferencedFiles } from '../utils/markdown.js';
@@ -9,6 +9,7 @@ import { ToolDefinition } from './tool-definition.js';
 import { getRequiredLanguageModelTokenUsage, getTrimmedReasoningText } from '../utils/ai-sdk.js';
 import { getModelCapabilityStatus, getReferencedFileInputCapabilities, logCapabilitySkip, warnIfCapabilitiesUndeclared, } from './capabilities.js';
 import { refreshSessionTokenLimitState } from './token-limits.js';
+import { getConfiguredModelDefinition, getModelDefinitionForVersion, getModelVersionLabel, modelVersionMatchesDefinition, } from './model-definition-filters.js';
 /**
  * Logs the number of skipped tests based on the current attempt and total attempts.
  * @param attempts The total number of attempts for the test.
@@ -31,13 +32,19 @@ const getMissingTests = async (db, testsConfig, registry, envConfig, { log = tru
     }
     // we query the DB to get all missing tests not yet run
     const { testVersions, testToTagRels, tags, sessions, modelVersions, providers, models, testToSystemPromptVersionRels, promptVersions, structuredObjectVersions, toolVersions, testToToolVersionRels, } = schema;
-    const modelConfigsWithTemperature = testsConfig.candidates.filter(candidate => candidate.temperature !== undefined);
-    const modelConfigsWithTags = testsConfig.candidates.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0);
-    const modelConfigsWithProhibitedTags = testsConfig.candidates.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0);
+    const candidatesWithDefinitions = testsConfig.candidates.map(candidate => ({
+        ...candidate,
+        modelDefinition: getConfiguredModelDefinition(registry, candidate),
+    }));
+    const modelConfigsWithTemperature = candidatesWithDefinitions.filter(candidate => candidate.temperature !== undefined);
+    const modelConfigsWithTags = candidatesWithDefinitions.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0);
+    const modelConfigsWithProhibitedTags = candidatesWithDefinitions.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0);
     const missingTests = await db
         .select({
         modelVersionId: modelVersions.id,
         modelVersionCode: modelVersions.providerModelCode,
+        modelVersionExtraIdentifier: modelVersions.extraIdentifier,
+        modelVersionRuntimeOptionsJson: modelVersions.runtimeOptionsJson,
         providerCode: providers.code,
         testVersionId: testVersions.id,
         testContent: testVersions.content,
@@ -59,7 +66,7 @@ const getMissingTests = async (db, testsConfig, registry, envConfig, { log = tru
     })
         .from(modelVersions)
         .innerJoin(models, and(eq(models.id, modelVersions.modelId), eq(models.active, true), eq(modelVersions.active, true)))
-        .innerJoin(providers, and(eq(providers.id, modelVersions.providerId), eq(providers.active, true), or(...testsConfig.candidates.map(({ provider, model }) => and(eq(providers.code, provider), eq(modelVersions.providerModelCode, model))))))
+        .innerJoin(providers, and(eq(providers.id, modelVersions.providerId), eq(providers.active, true), or(...candidatesWithDefinitions.map(candidate => modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')))))
         // always true to fetch all possible test combinations (we will filter later - cross joins aren't supported in drizzle-orm as of now)
         .innerJoin(testVersions, and(eq(testVersions.id, testVersions.id), eq(testVersions.active, true)))
         // Join the expected structured object version if needed
@@ -72,8 +79,7 @@ const getMissingTests = async (db, testsConfig, registry, envConfig, { log = tru
         .leftJoin(sessions, and(eq(sessions.testVersionId, testVersions.id), eq(sessions.modelVersionId, modelVersions.id), eq(sessions.candidateSysPromptVersionId, promptVersions.id), eq(sessions.active, true), modelConfigsWithTemperature.length > 0
         ? sql `${sessions.temperature} = CASE
 								${sql.join(modelConfigsWithTemperature.map(candidate => sql `WHEN
-												${eq(modelVersions.providerModelCode, candidate.model)}
-												AND ${eq(providers.code, candidate.provider)}
+												${modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')}
 												THEN ${candidate.temperature}`))}
 								ELSE ${testsConfig.candidatesTemperature}
 							END`
@@ -99,11 +105,11 @@ const getMissingTests = async (db, testsConfig, registry, envConfig, { log = tru
             : []),
         // ensure we have all required tags for each model
         ...(modelConfigsWithTags.length > 0
-            ? modelConfigsWithTags.map(candidate => sql `sum(CASE WHEN ${or(ne(modelVersions.providerModelCode, candidate.model), ne(providers.code, candidate.provider), inArray(tags.name, candidate.requiredTags))} THEN 1 ELSE 0 END) > 0`)
+            ? modelConfigsWithTags.map(candidate => sql `sum(CASE WHEN ${or(not(modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')), inArray(tags.name, candidate.requiredTags))} THEN 1 ELSE 0 END) > 0`)
             : []),
         // ensure we don't have any prohibited tags for each model
         ...(modelConfigsWithProhibitedTags.length > 0
-            ? modelConfigsWithProhibitedTags.map(candidate => sql `sum(CASE WHEN ${and(eq(modelVersions.providerModelCode, candidate.model), eq(providers.code, candidate.provider), inArray(tags.name, candidate.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
+            ? modelConfigsWithProhibitedTags.map(candidate => sql `sum(CASE WHEN ${and(modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate'), inArray(tags.name, candidate.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
             : []),
     ]))
         // ordering by model id is important as Ollama and other local models have some initial load time to consider
@@ -111,8 +117,8 @@ const getMissingTests = async (db, testsConfig, registry, envConfig, { log = tru
         .orderBy(modelVersions.id, testVersions.id, promptVersions.id);
     const warnedModelReferences = new Set();
     return missingTests.filter(test => {
-        const modelReference = `${test.providerCode}:${test.modelVersionCode}`;
-        const modelDefinition = registry.modelsByReference.get(modelReference);
+        const modelReference = getModelVersionLabel(registry, test);
+        const modelDefinition = getModelDefinitionForVersion(registry, test);
         const files = getReferencedFiles(test.testContent, envConfig.AI_TESTER_TESTS_DIR);
         const outputRequirements = test.structuredObjectSchema
             ? ['structured']
@@ -140,7 +146,7 @@ export const runAllTestsWithDeps = async ({ db, testsConfig, registry, confirmRu
     const { sessions } = schema;
     const missingTests = await getMissingTests(db, testsConfig, registry, envConfig);
     const modelConfigsWithTemperature = testsConfig.candidates.filter(candidate => candidate.temperature !== undefined);
-    const modelsWithTemperatures = new Map(modelConfigsWithTemperature.map(({ provider, model, temperature }) => [`${provider}:${model}`, temperature]));
+    const modelsWithTemperatures = new Map(modelConfigsWithTemperature.map(({ id, temperature }) => [id, temperature]));
     // The total number of missing tests needs to account for the number of attempts
     const totalMissingTests = missingTests.reduce((acc, test) => acc + (testsConfig.attempts - test.sessionsCount), 0);
     if (totalMissingTests === 0) {
@@ -157,9 +163,9 @@ export const runAllTestsWithDeps = async ({ db, testsConfig, registry, confirmRu
         const provider = getProvider(test.providerCode);
         if (!provider)
             throw new Error(`Provider ${test.providerCode} not found`);
-        const modelDefinition = registry.modelsByReference.get(`${test.providerCode}:${test.modelVersionCode}`);
+        const modelDefinition = getModelDefinitionForVersion(registry, test);
         const model = wrapModel(provider(test.modelVersionCode), 'candidate', modelDefinition);
-        const temperature = modelsWithTemperatures.get(`${test.providerCode}:${test.modelVersionCode}`) ?? testsConfig.candidatesTemperature;
+        const temperature = (modelDefinition ? modelsWithTemperatures.get(modelDefinition.id) : undefined) ?? testsConfig.candidatesTemperature;
         // We extract the array of messages
         const sections = getSectionsFromMarkdownContent(test.testContent);
         const files = getReferencedFiles(test.testContent, envConfig.AI_TESTER_TESTS_DIR, false, 'base64');

--- a/dist/src/main/stats.js
+++ b/dist/src/main/stats.js
@@ -1,14 +1,17 @@
-import { and, or, eq, ne, inArray, sql, countDistinct, desc, aliasedTable } from 'drizzle-orm';
+import { and, or, eq, not, inArray, sql, countDistinct, desc, aliasedTable } from 'drizzle-orm';
 import { schema } from '../database/schema.js';
 import {} from '../config/index.js';
 import { db } from '../database/db.js';
 import { sessionEvaluations } from '../database/schema/sessions.js';
+import { getFileBackedModelRegistry } from '../config/model-registry.js';
+import { getConfiguredModelDefinition, getModelVersionLabel, modelVersionMatchesDefinition, } from './model-definition-filters.js';
 /** Locale to use for currency formatting, determined by the JS runtime */
 const LOCALE = navigator.language ?? 'en-US';
 /** Extra digits beyond what is considered the smallest fraction digits for a given currency */
 const EXTRA_FRACTION_DIGITS = 2;
 export const showStats = async (query) => {
     console.log('Checking for stats...');
+    const registry = getFileBackedModelRegistry();
     if (query.candidates && query.candidates.length === 0) {
         console.log(`⚠️ Query "${query.description}" has no active candidate models.`);
         return;
@@ -17,14 +20,22 @@ export const showStats = async (query) => {
         console.log(`⚠️ Query "${query.description}" has no active evaluator models.`);
         return;
     }
-    const candidateModelConfigsWithTemperature = query.candidates?.filter(candidate => candidate.temperature !== undefined) ?? [];
-    const modelConfigsWithTags = query.candidates?.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0) ??
+    const candidatesWithDefinitions = query.candidates?.map(candidate => ({
+        ...candidate,
+        modelDefinition: getConfiguredModelDefinition(registry, candidate),
+    }));
+    const evaluatorsWithDefinitions = query.evaluators?.map(evaluator => ({
+        ...evaluator,
+        modelDefinition: getConfiguredModelDefinition(registry, evaluator),
+    }));
+    const candidateModelConfigsWithTemperature = candidatesWithDefinitions?.filter(candidate => candidate.temperature !== undefined) ?? [];
+    const modelConfigsWithTags = candidatesWithDefinitions?.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0) ??
         [];
-    const modelConfigsWithProhibitedTags = query.candidates?.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0) ?? [];
-    const evaluatorModelConfigsWithTemperature = query.evaluators?.filter(evaluator => evaluator.temperature !== undefined) ?? [];
-    const evaluatorModelConfigsWithTags = query.evaluators?.filter(evaluator => evaluator.requiredTags !== undefined && evaluator.requiredTags.length > 0) ??
+    const modelConfigsWithProhibitedTags = candidatesWithDefinitions?.filter(candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0) ?? [];
+    const evaluatorModelConfigsWithTemperature = evaluatorsWithDefinitions?.filter(evaluator => evaluator.temperature !== undefined) ?? [];
+    const evaluatorModelConfigsWithTags = evaluatorsWithDefinitions?.filter(evaluator => evaluator.requiredTags !== undefined && evaluator.requiredTags.length > 0) ??
         [];
-    const evaluatorModelConfigsWithProhibitedTags = query.evaluators?.filter(evaluator => evaluator.prohibitedTags !== undefined && evaluator.prohibitedTags.length > 0) ?? [];
+    const evaluatorModelConfigsWithProhibitedTags = evaluatorsWithDefinitions?.filter(evaluator => evaluator.prohibitedTags !== undefined && evaluator.prohibitedTags.length > 0) ?? [];
     const systemPromptRefs = query.systemPrompts ?? [];
     // we query the DB to get all missing tests not yet run
     const { testVersions, testToTagRels, tags, sessions, models, modelVersions, providers, currencies, currencyRates, modelCosts, prompts, promptVersions, } = schema;
@@ -39,6 +50,8 @@ export const showStats = async (query) => {
         .select({
         testVersionId: testVersions.id,
         modelVersionCode: modelVersions.providerModelCode,
+        modelVersionExtraIdentifier: modelVersions.extraIdentifier,
+        modelVersionRuntimeOptionsJson: modelVersions.runtimeOptionsJson,
         providerCode: providers.code,
         // Drizzle-ORM doesn't auto-alias columns, and does not support aliasing columns manually, so we have to use the raw SQL
         // (but this makes it impossible to use the column in the group by clause of the outer query - which is why we ignore the TS error)
@@ -58,21 +71,20 @@ export const showStats = async (query) => {
         .innerJoin(sessionEvaluations, and(eq(sessionEvaluations.sessionId, sessions.id), eq(sessionEvaluations.active, true), evaluatorModelConfigsWithTemperature.length > 0
         ? sql `${sessionEvaluations.temperature} = CASE
 							${sql.join(evaluatorModelConfigsWithTemperature.map(evaluator => sql `WHEN
-											${eq(evaluatorModelVersionAlias.providerModelCode, evaluator.model)}
-											AND ${eq(evaluatorProviderAlias.code, evaluator.provider)}
+											${modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator')}
 											THEN ${evaluator.temperature}`))}
 							ELSE ${query.evaluatorsTemperature ?? sessionEvaluations.temperature}
 						END`
         : eq(sessionEvaluations.temperature, query.evaluatorsTemperature ?? sessionEvaluations.temperature)))
-        .innerJoin(modelVersions, and(eq(sessions.modelVersionId, modelVersions.id), eq(modelVersions.active, true), ...(query.candidates
+        .innerJoin(modelVersions, and(eq(sessions.modelVersionId, modelVersions.id), eq(modelVersions.active, true), ...(candidatesWithDefinitions
         ? [
-            or(...query.candidates.map(({ provider, model }) => and(eq(providers.code, provider), eq(modelVersions.providerModelCode, model)))),
+            or(...candidatesWithDefinitions.map(candidate => modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate'))),
         ]
         : [])))
         .innerJoin(candidateModelAlias, and(eq(candidateModelAlias.id, modelVersions.modelId), eq(candidateModelAlias.active, true)))
-        .innerJoin(evaluatorModelVersionAlias, and(eq(sessionEvaluations.modelVersionId, evaluatorModelVersionAlias.id), eq(evaluatorModelVersionAlias.active, true), ...(query.evaluators
+        .innerJoin(evaluatorModelVersionAlias, and(eq(sessionEvaluations.modelVersionId, evaluatorModelVersionAlias.id), eq(evaluatorModelVersionAlias.active, true), ...(evaluatorsWithDefinitions
         ? [
-            or(...query.evaluators.map(({ provider, model }) => and(eq(evaluatorProviderAlias.code, provider), eq(evaluatorModelVersionAlias.providerModelCode, model)))),
+            or(...evaluatorsWithDefinitions.map(evaluator => modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator'))),
         ]
         : [])))
         .innerJoin(providers, and(eq(providers.id, modelVersions.providerId), eq(providers.active, true)))
@@ -90,8 +102,7 @@ export const showStats = async (query) => {
         .where(and(eq(sessions.active, true), candidateModelConfigsWithTemperature.length > 0
         ? sql `${sessions.temperature} = CASE
 							${sql.join(candidateModelConfigsWithTemperature.map(candidate => sql `WHEN
-											${eq(modelVersions.providerModelCode, candidate.model)}
-											AND ${eq(providers.code, candidate.provider)}
+											${modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')}
 											THEN ${candidate.temperature}`))}
 							ELSE ${query.candidatesTemperature ?? sessions.temperature}
 						END`
@@ -116,19 +127,19 @@ export const showStats = async (query) => {
             : []),
         // ensure we have all required tags for each candidate model
         ...(modelConfigsWithTags.length > 0
-            ? modelConfigsWithTags.map(candidate => sql `sum(CASE WHEN ${or(ne(modelVersions.providerModelCode, candidate.model), ne(providers.code, candidate.provider), inArray(tags.name, candidate.requiredTags))} THEN 1 ELSE 0 END) > 0`)
+            ? modelConfigsWithTags.map(candidate => sql `sum(CASE WHEN ${or(not(modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')), inArray(tags.name, candidate.requiredTags))} THEN 1 ELSE 0 END) > 0`)
             : []),
         // ensure we don't have any prohibited tags for each candidate model
         ...(modelConfigsWithProhibitedTags.length > 0
-            ? modelConfigsWithProhibitedTags.map(candidate => sql `sum(CASE WHEN ${and(eq(modelVersions.providerModelCode, candidate.model), eq(providers.code, candidate.provider), inArray(tags.name, candidate.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
+            ? modelConfigsWithProhibitedTags.map(candidate => sql `sum(CASE WHEN ${and(modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate'), inArray(tags.name, candidate.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
             : []),
         // ensure we have all required tags for each evaluator model
         ...(evaluatorModelConfigsWithTags.length > 0
-            ? evaluatorModelConfigsWithTags.map(evaluator => sql `sum(CASE WHEN ${or(ne(evaluatorModelVersionAlias.providerModelCode, evaluator.model), ne(evaluatorProviderAlias.code, evaluator.provider), inArray(tags.name, evaluator.requiredTags))} THEN 1 ELSE 0 END) > 0`)
+            ? evaluatorModelConfigsWithTags.map(evaluator => sql `sum(CASE WHEN ${or(not(modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator')), inArray(tags.name, evaluator.requiredTags))} THEN 1 ELSE 0 END) > 0`)
             : []),
         // ensure we don't have any prohibited tags for each evaluator model
         ...(evaluatorModelConfigsWithProhibitedTags.length > 0
-            ? evaluatorModelConfigsWithProhibitedTags.map(evaluator => sql `sum(CASE WHEN ${and(eq(evaluatorModelVersionAlias.providerModelCode, evaluator.model), eq(evaluatorProviderAlias.code, evaluator.provider), inArray(tags.name, evaluator.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
+            ? evaluatorModelConfigsWithProhibitedTags.map(evaluator => sql `sum(CASE WHEN ${and(modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator'), inArray(tags.name, evaluator.prohibitedTags))} THEN 1 ELSE 0 END) = 0`)
             : []),
     ]))
         .orderBy(desc(sql `CAST(SUM(${sessionEvaluations.pass}) AS REAL) / COUNT(${sessionEvaluations.pass})`)));
@@ -182,6 +193,8 @@ export const showStats = async (query) => {
         testsCount: countDistinct(cte.testVersionId),
         evalsCount: sql `SUM(${cte.evalsCount})`,
         modelVersionCode: cte.modelVersionCode,
+        modelVersionExtraIdentifier: cte.modelVersionExtraIdentifier,
+        modelVersionRuntimeOptionsJson: cte.modelVersionRuntimeOptionsJson,
         providerCode: cte.providerCode,
         passRate: passRateQuery,
         costPerSession: costPerSessionQuery.as('costPerSession'),
@@ -209,7 +222,7 @@ export const showStats = async (query) => {
     });
     console.table(Object.fromEntries(stats.map(result => {
         return [
-            result.modelVersionCode,
+            getModelVersionLabel(registry, result),
             {
                 Provider: result.providerCode,
                 '✅%': Number((result.passRate * 100).toFixed(0)),

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -2,9 +2,9 @@
 
 The config file is the source of truth for which tests, evaluations, and analysis queries should run. Current and past runs are stored in the database.
 
-The `provider` + `model` references in this file are matched against the active provider/model YAML registry described in [models.md](models.md).
+Model references in this file are matched by `id` against the active model YAML registry described in [models.md](models.md).
 
-If a referenced provider/model pair is not currently available, the app prints a warning at startup and skips that entry.
+If a referenced model id is not currently available, the app prints a warning at startup and skips that entry.
 
 ## Creating the config file
 
@@ -20,12 +20,9 @@ AI_TESTER_CONFIG_PATH=.local/ai-tester.config.yaml
 # Description: Configuration file for the tests to run
 
 # Model versions to test
-# 🚨 the `model` key is the providerModelCode from the corresponding model YAML file
 candidates:
-  - provider: ollama
-    model: gemma2:2b-instruct-q8_0
-  - provider: ollama
-    model: gemma2:9b-instruct-q4_K_M
+  - id: ollama/gemma2:2b-instruct-q8_0/default
+  - id: ollama/gemma2:9b-instruct-q4_K_M/default
 
     # The options here are per model options, and can be applied to candidate or evaluator models
     # [optional] Default temperature to apply to this model (overriding the global default temperature)
@@ -62,10 +59,8 @@ prohibitedTags:
 
 # Models to use to evaluate the generated responses
 evaluators:
-  - provider: ollama
-    model: gemma2:9b-instruct-q4_K_M
-  - provider: ollama
-    model: mistral-nemo:12b-instruct-2407-q4_K_M
+  - id: ollama/gemma2:9b-instruct-q4_K_M/default
+  - id: ollama/mistral-nemo:12b-instruct-2407-q4_K_M/default
 
     # The same options as for candidate models can be applied to evaluator models
 
@@ -104,16 +99,14 @@ analysisQueries:
 
     # [optional] Candidate model versions to include - follows a similar format to the main section
     candidates:
-      - provider: ollama
-        model: phi4:14b-q4_K_M
+      - id: ollama/phi4:14b-q4_K_M/default
 
         # temperature and tags can be applied to models in analysis queries as well
         # (not specified means no restriction for this model)
 
     # [optional] Evaluators to include - follows a similar format to the main section
     evaluators:
-      - provider: ollama
-        model: phi4:14b-q4_K_M
+      - id: ollama/phi4:14b-q4_K_M/default
 
         # temperature and tags can be applied to models in analysis queries as well
         # (not specified means no restriction for this model)
@@ -121,12 +114,10 @@ analysisQueries:
 
 ### Model references
 
-A provider/model pair in the config maps to:
+A model id in the config maps to one active model YAML definition.
 
-- a provider YAML file
-- a model YAML file whose `providerModelCode` matches the `model` value
-
-The model grouping `code` from the model YAML is not used directly in this config file.
+Use `ai-tester list --models` to print active ids in the override-ready JSON format.
+The model grouping `code`, provider code, and provider-facing `providerModelCode` from model YAML files are not used directly in this config file.
 
 ### Analysis queries
 

--- a/docs/example/ai-tester.config.yaml
+++ b/docs/example/ai-tester.config.yaml
@@ -2,14 +2,10 @@
 
 candidatesTemperature: 0.3
 candidates:
-  - provider: ollama
-    model: phi4:14b-q4_K_M
-  - provider: openai
-    model: gpt-4o-mini-2024-07-18
-  - provider: openrouter
-    model: openai/gpt-4o-mini
-  - provider: vertex
-    model: gemini-1.5-flash-002
+  - id: ollama/phi4:14b-q4_K_M/default
+  - id: openai/gpt-4o-mini-2024-07-18/reasoning-low
+  - id: openrouter/openai-gpt-4o-mini/default
+  - id: vertex/gemini-1.5-flash-002/default
 
 attempts: 1
 
@@ -26,16 +22,11 @@ requiredTags2:
 evaluatorsTemperature: 0.5
 evaluationsPerEvaluator: 2
 evaluators:
-  - provider: ollama
-    model: gemma2:9b-instruct-q4_K_M
-  - provider: ollama
-    model: mistral-nemo:12b-instruct-2407-q4_K_M
-  - provider: ollama
-    model: phi4:14b-q4_K_M
-  - provider: openai
-    model: gpt-4o-mini-2024-07-18
-  - provider: vertex
-    model: gemini-1.5-flash-002
+  - id: ollama/gemma2:9b-instruct-q4_K_M/default
+  - id: ollama/mistral-nemo:12b-instruct-2407-q4_K_M/default
+  - id: ollama/phi4:14b-q4_K_M/default
+  - id: openai/gpt-4o-mini-2024-07-18/reasoning-low
+  - id: vertex/gemini-1.5-flash-002/default
 
 analysisQueries:
   - description: All models (JPY costs)
@@ -48,5 +39,4 @@ analysisQueries:
     requiredTags2:
       - reasoning
     candidates:
-      - provider: ollama
-        model: phi4:14b-q4_K_M
+      - id: ollama/phi4:14b-q4_K_M/default

--- a/docs/example/data/models/openai/gpt-4o-mini.yaml
+++ b/docs/example/data/models/openai/gpt-4o-mini.yaml
@@ -1,6 +1,9 @@
+id: openai/gpt-4o-mini-2024-07-18/reasoning-low
 code: gpt-4o-mini
 provider: openai
 providerModelCode: gpt-4o-mini-2024-07-18
+uniqueProperties:
+  - thinking.effort
 thinking:
   effort: low
 capabilities:

--- a/docs/example/data/models/openrouter/openai-gpt-4o-mini.yaml
+++ b/docs/example/data/models/openrouter/openai-gpt-4o-mini.yaml
@@ -1,3 +1,4 @@
+id: openrouter/openai-gpt-4o-mini/default
 code: gpt-4o-mini-openrouter
 provider: openrouter
 providerModelCode: openai/gpt-4o-mini

--- a/docs/models.md
+++ b/docs/models.md
@@ -2,14 +2,13 @@
 
 Providers and model versions are defined from YAML files and then synchronized into the database.
 
-The main test config still references models with:
+The main test config references model definitions by `id`:
 
 ```yaml
-provider: openai
-model: gpt-4o-mini-2024-07-18
+id: openai/gpt-4o-mini-2024-07-18/reasoning-low
 ```
 
-The `model` value above is the `providerModelCode` from the model YAML file.
+Use an id that remains stable for the configured model definition. The recommended format is `{provider}/{providerModelCode}/{suffix}`.
 
 ## Provider files
 
@@ -50,6 +49,7 @@ Create one YAML file per runnable provider model under `AI_TESTER_MODELS_DIR`.
 Example:
 
 ```yaml
+id: vertex/gemini-2.5-flash/default
 code: gemini-2.5-flash
 provider: vertex
 providerModelCode: gemini-2.5-flash
@@ -84,11 +84,13 @@ costs:
 
 Fields:
 
+- `id`: The public model-definition id used by config files. If omitted, it defaults to `{provider}/{providerModelCode}` for migration compatibility. Add an explicit suffix when defining variants of the same provider model.
 - `code`: The internal shared model code used for grouping and analysis.
 - `provider`: The provider code from the provider YAML file.
 - `providerModelCode`: The provider-facing runtime model identifier.
 - `extraIdentifier`: Optional provider-specific identifier.
 - `active`: Optional model-version switch. Defaults to `true`. Inactive model versions are excluded from runs and reports.
+- `uniqueProperties`: Optional list of versioned runtime property paths that explain what makes this definition unique among active variants of the same provider model.
 - `providerOptions`: Optional provider-specific request fields to pass through for this model version.
 - `thinking`: Optional per-model thinking/reasoning settings. Use this for provider-agnostic options such as reasoning effort, thinking token budgets, or custom reasoning tag extraction when supported by the provider wrapper.
 - `capabilities`: Optional model capability declaration used to skip unsupported test/model pairs before provider calls. When omitted, runs preserve current behavior and print a warning. When present, omitted capability keys default to `false`.
@@ -106,6 +108,21 @@ Fields:
 - Ollama: `extractionTagName` and `enabled` for reasoning extraction
 
 When the same model needs different runtime options as a candidate versus an evaluator, put the shared settings in `providerOptions` / `thinking` and only the differences in `candidateOverrides` / `evaluatorOverrides`.
+
+When multiple active YAML files share the same `provider` and `providerModelCode`, each variant must have a distinct `id` and declare `uniqueProperties` whose values distinguish the variants. Unique properties must refer to versioned runtime settings such as `extraIdentifier`, `providerOptions`, `thinking`, `candidateOverrides`, or `evaluatorOverrides`.
+
+Example:
+
+```yaml
+id: openai/gpt-4o-mini/reasoning-high
+code: gpt-4o-mini
+provider: openai
+providerModelCode: gpt-4o-mini
+uniqueProperties:
+  - thinking.effort
+thinking:
+  effort: high
+```
 
 Capability checks use these fields:
 
@@ -129,13 +146,13 @@ After syncing:
 - historical sessions and evaluations remain in the database
 - if a YAML file is restored later, the matching row becomes active again
 - changing `providerOptions`, `thinking`, `candidateOverrides`, or `evaluatorOverrides` creates a new `model_versions` row in the database for that provider model identity
-- for multiple YAML entries sharing the same provider and `providerModelCode`, at most one may have `active: true`
-- if more than one active variant exists for the same provider/model code, startup fails and you must set `active: false` on the older variants
+- adding an `id` to an existing model YAML file does not create a new `model_versions` row by itself
+- multiple YAML entries may share the same provider and `providerModelCode` when their active definitions have distinct ids and declared `uniqueProperties`
 - inactive providers, models, and model versions are excluded from new runs and reports
 
 ## Missing configured models
 
-If the main config references a provider/model pair that is not currently available from YAML, the app prints a warning at startup and skips that entry. This behaves the same as omitting that model from the config.
+If the main config references a model id that is not currently available from YAML, the app prints a warning at startup and skips that entry. This behaves the same as omitting that model from the config.
 
 ## Token-limit reruns
 
@@ -161,7 +178,7 @@ The transition is straightforward:
 2. Create those directories on disk.
 3. Convert each provider into a provider-only YAML file.
 4. Convert each runnable model version into its own model YAML file, including full `costs` history.
-5. Keep the main test config as `provider` + `model`, where `model` is the `providerModelCode`.
+5. Update the main test config to reference model definition ids.
 6. Run migrations.
 7. Run the database sync from files.
 
@@ -170,5 +187,5 @@ Rows without matching YAML simply become inactive until corresponding YAML files
 Practical notes:
 
 - If the registry directories are missing, the app fails at startup rather than guessing.
-- If the main config references a provider/model pair that is not yet present in YAML, that entry is warned about and skipped.
+- If the main config references a model id that is not yet present in YAML, that entry is warned about and skipped.
 - If historical runs exist for a model version, make sure the YAML `costs` history starts early enough to cover the oldest recorded run.

--- a/skills/ai-tester/references/running.md
+++ b/skills/ai-tester/references/running.md
@@ -40,8 +40,8 @@ ai-tester run-evals --dry-run --include-counts
 Use runtime overrides for temporary scope changes instead of editing config:
 
 ```sh
-ai-tester run-tests --dry-run --config-overrides '{"attempts":2,"requiredTags1":["smoke"],"candidates":[{"provider":"openai","model":"gpt-4o-mini-2024-07-18"}]}'
-ai-tester run-evals --dry-run --config-overrides '{"requiredTags2":["reasoning"],"evaluationsPerEvaluator":2,"evaluators":[{"provider":"openai","model":"gpt-4o-mini-2024-07-18"}]}'
+ai-tester run-tests --dry-run --config-overrides '{"attempts":2,"requiredTags1":["smoke"],"candidates":[{"id":"openai/gpt-4o-mini-2024-07-18/default"}]}'
+ai-tester run-evals --dry-run --config-overrides '{"requiredTags2":["reasoning"],"evaluationsPerEvaluator":2,"evaluators":[{"id":"openai/gpt-4o-mini-2024-07-18/default"}]}'
 ai-tester run-evals --config-overrides-file .local/eval-overrides.json
 ```
 
@@ -49,7 +49,7 @@ ai-tester run-evals --config-overrides-file .local/eval-overrides.json
 
 `run-evals` overrides can include all test-run override fields plus `evaluators`, `evaluatorsTemperature`, and `evaluationsPerEvaluator`.
 
-Model entries use `{ "provider": "...", "model": "..." }`, where `model` is the provider-facing model code from the configured model registry. Per-model `temperature`, `requiredTags`, and `prohibitedTags` are also valid when the user asks for model-specific scope.
+Model entries use `{ "id": "..." }`, where `id` is the model definition id from the configured model registry. Per-model `temperature`, `requiredTags`, and `prohibitedTags` are also valid when the user asks for model-specific scope.
 
 ## Sync, Runs, And Stats
 
@@ -76,7 +76,7 @@ ai-tester stats --query "My query description"
 Use the listed configured query when the user asks for that named query, an existing report, or gives no special filters. If the user gives specific models, tags, prompts, temperatures, evaluators, or currency, use an ad hoc stats query instead:
 
 ```sh
-ai-tester stats --dry-run --query-json '{"currency":"USD","requiredTags1":["smoke"],"candidates":[{"provider":"openai","model":"gpt-4o-mini-2024-07-18"}]}'
+ai-tester stats --dry-run --query-json '{"currency":"USD","requiredTags1":["smoke"],"candidates":[{"id":"openai/gpt-4o-mini-2024-07-18/default"}]}'
 ai-tester stats --query-json '{"currency":"JPY","systemPrompts":["helpful"],"requiredTags2":["reasoning"],"candidatesTemperature":0.2}'
 ai-tester stats --dry-run --query-file .local/stats-query.json
 ```

--- a/src/cli/list-values.ts
+++ b/src/cli/list-values.ts
@@ -33,7 +33,7 @@ const formatSection = (title: string, values: string[], emptyMessage: string) =>
 
 export const listAvailableModels = () =>
 	getFileBackedModelRegistry()
-		.activeModels.map(model => JSON.stringify({ provider: model.provider, model: model.providerModelCode }))
+		.activeModels.map(model => JSON.stringify({ id: model.id }))
 		.sort((a, b) => a.localeCompare(b))
 
 export const listAvailableTags = () =>

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -16,8 +16,7 @@ export const RequiredTagsSchema = z.array(z.string()).default([])
 export const ProhibitedTagsSchema = z.array(z.string()).default(DEFAULT_PROHIBITED_TAGS)
 export const ConfiguredModelsSchema = z.array(
 	z.object({
-		provider: z.string(),
-		model: z.string(),
+		id: z.string().min(1),
 
 		/** Tags to include in this session for this model only (not provided means no restrictions) */
 		requiredTags: RequiredTagsSchema.optional(),
@@ -31,14 +30,13 @@ export const ConfiguredModelsSchema = z.array(
 ).superRefine((models, ctx) => {
 	const seen = new Set<string>()
 	for (const model of models) {
-		const key = `${model.provider}:${model.model}`
-		if (seen.has(key)) {
+		if (seen.has(model.id)) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: `Duplicate configured model reference: ${key}`,
+				message: `Duplicate configured model reference: ${model.id}`,
 			})
 		}
-		seen.add(key)
+		seen.add(model.id)
 	}
 })
 export type ConfiguredModel = z.infer<typeof ConfiguredModelsSchema>[number]

--- a/src/config/model-registry.ts
+++ b/src/config/model-registry.ts
@@ -89,55 +89,72 @@ const RuntimeOptionsOverrideSchema = z.object({
 })
 export type RuntimeOptionsOverride = z.infer<typeof RuntimeOptionsOverrideSchema>
 
-export const ModelDefinitionSchema = z.object({
-	code: z.string(),
-	provider: z.string(),
-	providerModelCode: z.string(),
-	extraIdentifier: z.preprocess(
-		value => {
-			if (typeof value !== 'string') return value
-			const normalized = value.trim()
-			return normalized === '' ? undefined : normalized
-		},
-		z.string().optional()
-	),
-	active: z.boolean().default(true),
-	providerOptions: z.record(JsonValueSchema).default({}),
-	thinking: ThinkingConfigSchema,
-	capabilities: ModelCapabilitiesSchema.optional(),
-	candidateOverrides: RuntimeOptionsOverrideSchema.optional(),
-	evaluatorOverrides: RuntimeOptionsOverrideSchema.optional(),
-	costs: z
-		.array(CostDefinitionSchema)
-		.default([])
-		.superRefine((costs, ctx) => {
-			const seen = new Set<string>()
-			for (const cost of costs) {
-				if (Number.isNaN(new Date(cost.validFrom).valueOf())) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: `Invalid validFrom date: ${cost.validFrom}`,
-					})
-				}
+const VERSIONED_MODEL_PROPERTY_PREFIXES = [
+	'extraIdentifier',
+	'providerOptions',
+	'thinking',
+	'candidateOverrides',
+	'evaluatorOverrides',
+] as const
 
-				if (seen.has(cost.validFrom)) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: `Duplicate cost entry for validFrom ${cost.validFrom}`,
-					})
+export const ModelDefinitionSchema = z
+	.object({
+		id: z.string().min(1).optional(),
+		code: z.string(),
+		provider: z.string(),
+		providerModelCode: z.string(),
+		extraIdentifier: z.preprocess(
+			value => {
+				if (typeof value !== 'string') return value
+				const normalized = value.trim()
+				return normalized === '' ? undefined : normalized
+			},
+			z.string().optional()
+		),
+		active: z.boolean().default(true),
+		providerOptions: z.record(JsonValueSchema).default({}),
+		thinking: ThinkingConfigSchema,
+		capabilities: ModelCapabilitiesSchema.optional(),
+		candidateOverrides: RuntimeOptionsOverrideSchema.optional(),
+		evaluatorOverrides: RuntimeOptionsOverrideSchema.optional(),
+		uniqueProperties: z.array(z.string().min(1)).default([]),
+		costs: z
+			.array(CostDefinitionSchema)
+			.default([])
+			.superRefine((costs, ctx) => {
+				const seen = new Set<string>()
+				for (const cost of costs) {
+					if (Number.isNaN(new Date(cost.validFrom).valueOf())) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							message: `Invalid validFrom date: ${cost.validFrom}`,
+						})
+					}
+
+					if (seen.has(cost.validFrom)) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							message: `Duplicate cost entry for validFrom ${cost.validFrom}`,
+						})
+					}
+					seen.add(cost.validFrom)
 				}
-				seen.add(cost.validFrom)
-			}
-		}),
-})
+			}),
+	})
+	.transform(model => ({
+		...model,
+		id: model.id ?? `${model.provider}/${model.providerModelCode}`,
+	}))
 export type ModelDefinition = z.infer<typeof ModelDefinitionSchema>
+export type ModelRole = 'candidate' | 'evaluator'
 
 export type FileBackedModelRegistry = {
 	providers: ProviderDefinition[]
 	providersByCode: Map<string, ProviderDefinition>
 	models: ModelDefinition[]
 	activeModels: ModelDefinition[]
-	modelsByReference: Map<string, ModelDefinition>
+	modelsById: Map<string, ModelDefinition>
+	modelsByRuntimeIdentity: Map<string, ModelDefinition>
 }
 
 const getYamlFilesOrThrow = (basePath: string, label: string) => {
@@ -160,31 +177,9 @@ export const getModelRuntimeOptions = (model: Pick<ModelDefinition, 'providerOpt
 	thinking: model.thinking ?? null,
 })
 
-export const getRoleAwareModelRuntimeOptions = (
-	model: Pick<ModelDefinition, 'providerOptions' | 'thinking' | 'candidateOverrides' | 'evaluatorOverrides'>
-) => ({
-	...getModelRuntimeOptions(model),
-	...(model.candidateOverrides !== undefined
-		? {
-				candidateOverrides: {
-					providerOptions: model.candidateOverrides.providerOptions ?? {},
-					thinking: model.candidateOverrides.thinking ?? null,
-				},
-			}
-		: {}),
-	...(model.evaluatorOverrides !== undefined
-		? {
-				evaluatorOverrides: {
-					providerOptions: model.evaluatorOverrides.providerOptions ?? {},
-					thinking: model.evaluatorOverrides.thinking ?? null,
-				},
-			}
-		: {}),
-})
-
 export const getEffectiveModelRuntimeOptions = (
 	model: Pick<ModelDefinition, 'providerOptions' | 'thinking' | 'candidateOverrides' | 'evaluatorOverrides'>,
-	type: 'candidate' | 'evaluator'
+	type: ModelRole
 ) => {
 	const overrides = type === 'candidate' ? model.candidateOverrides : model.evaluatorOverrides
 	return {
@@ -203,10 +198,49 @@ export const getEffectiveModelRuntimeOptions = (
 }
 
 export const getModelRuntimeOptionsJson = (
-	model: Pick<ModelDefinition, 'providerOptions' | 'thinking' | 'candidateOverrides' | 'evaluatorOverrides'>
-) => stableJsonStringify(getRoleAwareModelRuntimeOptions(model))
+	model: Pick<ModelDefinition, 'providerOptions' | 'thinking' | 'candidateOverrides' | 'evaluatorOverrides'>,
+	role: ModelRole
+) => {
+	const options = getEffectiveModelRuntimeOptions(model, role)
+	return stableJsonStringify({
+		providerOptions: options.providerOptions,
+		thinking: options.thinking ?? null,
+	})
+}
 
-const getModelIdentityKey = (
+export const getModelRuntimeIdentityKeyFromParts = ({
+	provider,
+	providerModelCode,
+	extraIdentifier,
+	runtimeOptionsJson,
+}: {
+	provider: string
+	providerModelCode: string
+	extraIdentifier?: string | null
+	runtimeOptionsJson: string
+}) => `${provider}:${providerModelCode}:${extraIdentifier ?? ''}:${runtimeOptionsJson}`
+
+export const getModelRuntimeIdentityKey = (
+	model: Pick<
+		ModelDefinition,
+		| 'provider'
+		| 'providerModelCode'
+		| 'extraIdentifier'
+		| 'providerOptions'
+		| 'thinking'
+		| 'candidateOverrides'
+		| 'evaluatorOverrides'
+	>,
+	role: ModelRole
+) =>
+	getModelRuntimeIdentityKeyFromParts({
+		provider: model.provider,
+		providerModelCode: model.providerModelCode,
+		extraIdentifier: model.extraIdentifier,
+		runtimeOptionsJson: getModelRuntimeOptionsJson(model, role),
+	})
+
+export const getModelRuntimeIdentityKeys = (
 	model: Pick<
 		ModelDefinition,
 		| 'provider'
@@ -217,30 +251,99 @@ const getModelIdentityKey = (
 		| 'candidateOverrides'
 		| 'evaluatorOverrides'
 	>
-) => `${model.provider}:${model.providerModelCode}:${model.extraIdentifier ?? ''}:${getModelRuntimeOptionsJson(model)}`
+) => Array.from(new Set((['candidate', 'evaluator'] as const).map(role => getModelRuntimeIdentityKey(model, role))))
+
+export const getModelRuntimeIdentities = (
+	model: Pick<
+		ModelDefinition,
+		| 'provider'
+		| 'providerModelCode'
+		| 'extraIdentifier'
+		| 'providerOptions'
+		| 'thinking'
+		| 'candidateOverrides'
+		| 'evaluatorOverrides'
+	>
+) => {
+	const identities = new Map<string, { key: string; runtimeOptionsJson: string }>()
+	for (const role of ['candidate', 'evaluator'] as const) {
+		const runtimeOptionsJson = getModelRuntimeOptionsJson(model, role)
+		const key = getModelRuntimeIdentityKeyFromParts({
+			provider: model.provider,
+			providerModelCode: model.providerModelCode,
+			extraIdentifier: model.extraIdentifier,
+			runtimeOptionsJson,
+		})
+		identities.set(key, { key, runtimeOptionsJson })
+	}
+	return Array.from(identities.values())
+}
+
+const getModelPropertyValue = (model: ModelDefinition, propertyPath: string) => {
+	const pathParts = propertyPath.split('.')
+	let value: unknown = model
+
+	for (const pathPart of pathParts) {
+		if (value === null || typeof value !== 'object' || !Object.prototype.hasOwnProperty.call(value, pathPart)) {
+			return undefined
+		}
+		value = (value as Record<string, unknown>)[pathPart]
+	}
+
+	return value
+}
+
+const validateUniqueProperties = (model: ModelDefinition) => {
+	for (const propertyPath of model.uniqueProperties) {
+		if (!VERSIONED_MODEL_PROPERTY_PREFIXES.some(prefix => propertyPath === prefix || propertyPath.startsWith(`${prefix}.`))) {
+			throw new Error(
+				`Model ${model.id} declares unsupported uniqueProperties path ${propertyPath}. Unique properties must reference versioned runtime settings: ${VERSIONED_MODEL_PROPERTY_PREFIXES.join(', ')}.`
+			)
+		}
+		if (getModelPropertyValue(model, propertyPath) === undefined) {
+			throw new Error(`Model ${model.id} declares uniqueProperties path ${propertyPath}, but that value is not set.`)
+		}
+	}
+}
+
+const getUniquePropertiesKey = (model: ModelDefinition) =>
+	stableJsonStringify(
+		Object.fromEntries(model.uniqueProperties.map(propertyPath => [propertyPath, getModelPropertyValue(model, propertyPath)]))
+	)
 
 const getActiveModels = (models: ModelDefinition[]) => {
 	const groupedModels = new Map<string, ModelDefinition[]>()
+	const activeModels: ModelDefinition[] = []
 
 	for (const model of models) {
 		if (!model.active) continue
 		const key = getModelReferenceKey(model)
 		groupedModels.set(key, [...(groupedModels.get(key) ?? []), model])
+		activeModels.push(model)
 	}
 
-	const activeModels: ModelDefinition[] = []
 	for (const [reference, variants] of groupedModels) {
 		if (variants.length === 1) {
-			activeModels.push(variants[0])
 			continue
 		}
 
-		const details = variants
-			.map(model => `${model.code}${model.extraIdentifier ? ` (extraIdentifier: ${model.extraIdentifier})` : ''}`)
-			.join(', ')
-		throw new Error(
-			`Conflicting active model variants for ${reference}: ${details}. Set active: false on all but one YAML entry for this provider/model code combination.`
-		)
+		const variantsWithoutUniqueProperties = variants.filter(model => model.uniqueProperties.length === 0)
+		if (variantsWithoutUniqueProperties.length > 0) {
+			throw new Error(
+				`Active model variants for ${reference} must declare uniqueProperties: ${variantsWithoutUniqueProperties.map(model => model.id).join(', ')}.`
+			)
+		}
+
+		const uniquePropertyKeys = new Set<string>()
+		for (const variant of variants) {
+			const key = getUniquePropertiesKey(variant)
+			if (uniquePropertyKeys.has(key)) {
+				throw new Error(
+					`Active model variants for ${reference} do not have distinct uniqueProperties values: ${variants.map(model => model.id).join(', ')}.`
+				)
+			}
+			uniquePropertyKeys.add(key)
+		}
 	}
 
 	return activeModels
@@ -267,7 +370,8 @@ export const loadModelDefinitions = (providersByCode?: Map<string, ProviderDefin
 	const models: ModelDefinition[] = getYamlFilesOrThrow(envConfig.AI_TESTER_MODELS_DIR, 'Model registry').map(file =>
 		readYamlFile(file, ModelDefinitionSchema)
 	)
-	const seen = new Set<string>()
+	const seenRuntimeIdentities = new Set<string>()
+	const seenIds = new Set<string>()
 
 	for (const model of models) {
 		if (!providerMap.has(model.provider)) {
@@ -276,13 +380,22 @@ export const loadModelDefinitions = (providersByCode?: Map<string, ProviderDefin
 			)
 		}
 
-		const key = getModelIdentityKey(model)
-		if (seen.has(key)) {
-			throw new Error(
-				`Duplicate runtime model identity found in YAML files: ${key}. Each provider/providerModelCode/extraIdentifier combination must map to exactly one YAML entry.`
-			)
+		if (model.active) {
+			if (seenIds.has(model.id)) {
+				throw new Error(`Duplicate active model id found in YAML files: ${model.id}`)
+			}
+			seenIds.add(model.id)
 		}
-		seen.add(key)
+		validateUniqueProperties(model)
+
+		for (const key of getModelRuntimeIdentityKeys(model)) {
+			if (seenRuntimeIdentities.has(key)) {
+				throw new Error(
+					`Duplicate runtime model identity found in YAML files: ${key}. Each provider/providerModelCode/extraIdentifier/runtime-options combination must map to exactly one YAML entry.`
+				)
+			}
+			seenRuntimeIdentities.add(key)
+		}
 	}
 
 	return models
@@ -293,14 +406,18 @@ export const loadFileBackedModelRegistry = (): FileBackedModelRegistry => {
 	const providersByCode = new Map(providers.map(provider => [provider.code, provider]))
 	const models = loadModelDefinitions(providersByCode)
 	const activeModels = getActiveModels(models)
-	const modelsByReference = new Map(activeModels.map(model => [getModelReferenceKey(model), model]))
+	const modelsById = new Map(activeModels.map(model => [model.id, model]))
+	const modelsByRuntimeIdentity = new Map(
+		activeModels.flatMap(model => getModelRuntimeIdentityKeys(model).map(key => [key, model] as const))
+	)
 
 	return {
 		providers,
 		providersByCode,
 		models,
 		activeModels,
-		modelsByReference,
+		modelsById,
+		modelsByRuntimeIdentity,
 	}
 }
 
@@ -317,7 +434,7 @@ export const clearFileBackedModelRegistryCache = () => {
 
 const warnedContexts = new Set<string>()
 
-export const filterConfiguredModels = <T extends { provider: string; model: string }>(
+export const filterConfiguredModels = <T extends { id: string }>(
 	models: T[],
 	context: string,
 	registry: FileBackedModelRegistry = getFileBackedModelRegistry()
@@ -326,7 +443,7 @@ export const filterConfiguredModels = <T extends { provider: string; model: stri
 	const missingModels: T[] = []
 
 	for (const model of models) {
-		if (registry.modelsByReference.has(`${model.provider}:${model.model}`)) {
+		if (registry.modelsById.has(model.id)) {
 			availableModels.push(model)
 		} else {
 			missingModels.push(model)
@@ -335,11 +452,7 @@ export const filterConfiguredModels = <T extends { provider: string; model: stri
 
 	if (missingModels.length > 0 && !warnedContexts.has(context)) {
 		warnedContexts.add(context)
-		console.warn(
-			`Skipping unavailable models in ${context}: ${missingModels
-				.map(model => `${model.provider}:${model.model}`)
-				.join(', ')}`
-		)
+		console.warn(`Skipping unavailable models in ${context}: ${missingModels.map(model => model.id).join(', ')}`)
 	}
 
 	return {

--- a/src/main/evaluations.ts
+++ b/src/main/evaluations.ts
@@ -2,7 +2,7 @@
  * This module is responsible for running all session evaluations that have not been run yet.
  */
 
-import { and, or, eq, ne, inArray, sql, lt, countDistinct, aliasedTable } from 'drizzle-orm'
+import { and, or, eq, not, inArray, sql, lt, countDistinct, aliasedTable } from 'drizzle-orm'
 import { generateText, Output } from 'ai'
 import z from 'zod'
 
@@ -17,6 +17,12 @@ import {
 	type CapabilityRequirements,
 } from './capabilities.js'
 import { refreshEvaluationTokenLimitState } from './token-limits.js'
+import {
+	getConfiguredModelDefinition,
+	getModelDefinitionForVersion,
+	getModelVersionLabel,
+	modelVersionMatchesDefinition,
+} from './model-definition-filters.js'
 
 const evalSchema = z.object({
 	// Note: `.nullable()` is not supported by some providers (like Vertex AI) as it generates an unsupported `anyOf` schema
@@ -97,21 +103,30 @@ const getMissingEvaluations = async (
 		sessionEvaluations,
 	} = schema
 
-	const modelConfigsWithTemperature = testsConfig.evaluators.filter(evaluator => evaluator.temperature !== undefined)
-	const modelConfigsWithTags = testsConfig.evaluators.filter(
+	const evaluatorsWithDefinitions = testsConfig.evaluators.map(evaluator => ({
+		...evaluator,
+		modelDefinition: getConfiguredModelDefinition(registry, evaluator),
+	}))
+	const candidatesWithDefinitions = testsConfig.candidates.map(candidate => ({
+		...candidate,
+		modelDefinition: getConfiguredModelDefinition(registry, candidate),
+	}))
+
+	const modelConfigsWithTemperature = evaluatorsWithDefinitions.filter(evaluator => evaluator.temperature !== undefined)
+	const modelConfigsWithTags = evaluatorsWithDefinitions.filter(
 		candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0
 	)
-	const modelConfigsWithProhibitedTags = testsConfig.evaluators.filter(
+	const modelConfigsWithProhibitedTags = evaluatorsWithDefinitions.filter(
 		candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0
 	)
 
-	const candidateModelConfigsWithTemperature = testsConfig.candidates.filter(
+	const candidateModelConfigsWithTemperature = candidatesWithDefinitions.filter(
 		candidate => candidate.temperature !== undefined
 	)
-	const candidateModelConfigsWithTags = testsConfig.candidates.filter(
+	const candidateModelConfigsWithTags = candidatesWithDefinitions.filter(
 		candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0
 	)
-	const candidateModelConfigsWithProhibitedTags = testsConfig.candidates.filter(
+	const candidateModelConfigsWithProhibitedTags = candidatesWithDefinitions.filter(
 		candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0
 	)
 	const candidateModelVersionAlias = aliasedTable(modelVersions, 'candidate_model_version_alias')
@@ -124,6 +139,8 @@ const getMissingEvaluations = async (
 		.select({
 			modelVersionId: modelVersions.id,
 			modelVersionCode: modelVersions.providerModelCode,
+			modelVersionExtraIdentifier: modelVersions.extraIdentifier,
+			modelVersionRuntimeOptionsJson: modelVersions.runtimeOptionsJson,
 			providerCode: providers.code,
 			testVersionId: testVersions.id,
 			testContent: testVersions.content,
@@ -145,11 +162,7 @@ const getMissingEvaluations = async (
 			and(
 				eq(providers.id, modelVersions.providerId),
 				eq(providers.active, true),
-				or(
-					...testsConfig.evaluators.map(({ provider, model }) =>
-						and(eq(providers.code, provider), eq(modelVersions.providerModelCode, model))
-					)
-				)
+				or(...evaluatorsWithDefinitions.map(evaluator => modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator')))
 			)
 		)
 
@@ -165,8 +178,7 @@ const getMissingEvaluations = async (
 								candidateModelConfigsWithTemperature.map(
 									candidate =>
 										sql`WHEN
-											${eq(candidateModelVersionAlias.providerModelCode, candidate.model)}
-											AND ${eq(candidateProviderAlias.code, candidate.provider)}
+											${modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate')}
 											THEN ${candidate.temperature}`
 								)
 							)}
@@ -187,8 +199,8 @@ const getMissingEvaluations = async (
 				eq(candidateProviderAlias.id, candidateModelVersionAlias.providerId),
 				eq(candidateProviderAlias.active, true),
 				or(
-					...testsConfig.candidates.map(({ provider, model }) =>
-						and(eq(candidateProviderAlias.code, provider), eq(candidateModelVersionAlias.providerModelCode, model))
+					...candidatesWithDefinitions.map(candidate =>
+						modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate')
 					)
 				)
 			)
@@ -221,14 +233,13 @@ const getMissingEvaluations = async (
 				modelConfigsWithTemperature.length > 0
 					? sql`${sessionEvaluations.temperature} = CASE
 								${sql.join(
-									modelConfigsWithTemperature.map(
-										evaluator =>
-											sql`WHEN
-												${eq(modelVersions.providerModelCode, evaluator.model)}
-												AND ${eq(providers.code, evaluator.provider)}
+								modelConfigsWithTemperature.map(
+									evaluator =>
+										sql`WHEN
+												${modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator')}
 												THEN ${evaluator.temperature}`
-									)
-								)}
+								)
+							)}
 								ELSE ${testsConfig.evaluatorsTemperature}
 							END`
 					: eq(sessionEvaluations.temperature, testsConfig.evaluatorsTemperature)
@@ -271,8 +282,7 @@ const getMissingEvaluations = async (
 						? modelConfigsWithTags.map(
 								evaluator =>
 									sql`sum(CASE WHEN ${or(
-										ne(modelVersions.providerModelCode, evaluator.model),
-										ne(providers.code, evaluator.provider),
+										not(modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator')),
 										inArray(tags.name, evaluator.requiredTags!)
 									)} THEN 1 ELSE 0 END) > 0`
 						  )
@@ -283,8 +293,7 @@ const getMissingEvaluations = async (
 						? modelConfigsWithProhibitedTags.map(
 								evaluator =>
 									sql`sum(CASE WHEN ${and(
-										eq(modelVersions.providerModelCode, evaluator.model),
-										eq(providers.code, evaluator.provider),
+										modelVersionMatchesDefinition(providers, modelVersions, evaluator.modelDefinition, 'evaluator'),
 										inArray(tags.name, evaluator.prohibitedTags!)
 									)} THEN 1 ELSE 0 END) = 0`
 						  )
@@ -295,8 +304,7 @@ const getMissingEvaluations = async (
 						? candidateModelConfigsWithTags.map(
 								candidate =>
 									sql`sum(CASE WHEN ${or(
-										ne(candidateModelVersionAlias.providerModelCode, candidate.model),
-										ne(candidateProviderAlias.code, candidate.provider),
+										not(modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate')),
 										inArray(tags.name, candidate.requiredTags!)
 									)} THEN 1 ELSE 0 END) > 0`
 						  )
@@ -307,8 +315,7 @@ const getMissingEvaluations = async (
 						? candidateModelConfigsWithProhibitedTags.map(
 								candidate =>
 									sql`sum(CASE WHEN ${and(
-										eq(candidateModelVersionAlias.providerModelCode, candidate.model),
-										eq(candidateProviderAlias.code, candidate.provider),
+										modelVersionMatchesDefinition(candidateProviderAlias, candidateModelVersionAlias, candidate.modelDefinition, 'candidate'),
 										inArray(tags.name, candidate.prohibitedTags!)
 									)} THEN 1 ELSE 0 END) = 0`
 						  )
@@ -327,8 +334,8 @@ const getMissingEvaluations = async (
 		output: ['structured'],
 	}
 	return missingEvaluations.filter(evaluation => {
-		const modelReference = `${evaluation.providerCode}:${evaluation.modelVersionCode}`
-		const modelDefinition = registry.modelsByReference.get(modelReference)
+		const modelReference = getModelVersionLabel(registry, evaluation)
+		const modelDefinition = getModelDefinitionForVersion(registry, evaluation)
 		if (log) warnIfCapabilitiesUndeclared(modelDefinition, modelReference, warnedModelReferences)
 		const capabilityStatus = getModelCapabilityStatus(modelDefinition, requirements)
 		if (capabilityStatus && !capabilityStatus.supported) {
@@ -359,7 +366,7 @@ export const runAllEvaluationsWithDeps = async ({
 	const missingEvaluations = await getMissingEvaluations(db, testsConfig, registry, envConfig)
 	const modelConfigsWithTemperature = testsConfig.evaluators.filter(evaluator => evaluator.temperature !== undefined)
 	const modelsWithTemperatures = new Map<string, number>(
-		modelConfigsWithTemperature.map(({ provider, model, temperature }) => [`${provider}:${model}`, temperature!])
+		modelConfigsWithTemperature.map(({ id, temperature }) => [id, temperature!])
 	)
 
 	// The total number of missing evaluations needs to account for the number of judgments
@@ -383,12 +390,11 @@ export const runAllEvaluationsWithDeps = async ({
 	for (const evaluation of missingEvaluations) {
 		const provider = getProvider(evaluation.providerCode)
 		if (!provider) throw new Error(`Provider ${evaluation.providerCode} not found`)
-		const modelDefinition = registry.modelsByReference.get(`${evaluation.providerCode}:${evaluation.modelVersionCode}`)
+		const modelDefinition = getModelDefinitionForVersion(registry, evaluation)
 		const model = wrapModel(provider(evaluation.modelVersionCode), 'evaluator', modelDefinition)
 
 		const temperature =
-			modelsWithTemperatures.get(`${evaluation.providerCode}:${evaluation.modelVersionCode}`) ??
-			testsConfig.evaluatorsTemperature
+			(modelDefinition ? modelsWithTemperatures.get(modelDefinition.id) : undefined) ?? testsConfig.evaluatorsTemperature
 
 		// We extract the array of messages
 		const sections = getSectionsFromMarkdownContent(evaluation.evalPromptContent)

--- a/src/main/model-definition-filters.ts
+++ b/src/main/model-definition-filters.ts
@@ -1,0 +1,77 @@
+import { and, eq, isNull, type SQL } from 'drizzle-orm'
+
+import type { schema } from '../database/schema.js'
+import {
+	getModelRuntimeIdentityKeyFromParts,
+	getModelRuntimeOptionsJson,
+	type FileBackedModelRegistry,
+	type ModelDefinition,
+	type ModelRole,
+} from '../config/model-registry.js'
+
+type ConfiguredModelRef = { id: string }
+type ProviderColumns = Pick<typeof schema.providers, 'code'>
+type ModelVersionColumns = Pick<
+	typeof schema.modelVersions,
+	'providerModelCode' | 'extraIdentifier' | 'runtimeOptionsJson'
+>
+
+export type ModelVersionIdentityRow = {
+	providerCode: string
+	modelVersionCode: string
+	modelVersionExtraIdentifier: string | null
+	modelVersionRuntimeOptionsJson: string
+}
+
+export const getConfiguredModelDefinition = (
+	registry: FileBackedModelRegistry,
+	configuredModel: ConfiguredModelRef
+) => {
+	const modelDefinition = registry.modelsById.get(configuredModel.id)
+	if (!modelDefinition) {
+		throw new Error(`Configured model ${configuredModel.id} is not available in the active model registry.`)
+	}
+	return modelDefinition
+}
+
+export const getConfiguredModelDefinitions = (
+	registry: FileBackedModelRegistry,
+	configuredModels: ConfiguredModelRef[]
+) => configuredModels.map(configuredModel => getConfiguredModelDefinition(registry, configuredModel))
+
+export const modelVersionMatchesDefinition = (
+	providerTable: ProviderColumns,
+	modelVersionTable: ModelVersionColumns,
+	modelDefinition: ModelDefinition,
+	role: ModelRole
+): SQL =>
+	and(
+		eq(providerTable.code, modelDefinition.provider),
+		eq(modelVersionTable.providerModelCode, modelDefinition.providerModelCode),
+		eq(modelVersionTable.runtimeOptionsJson, getModelRuntimeOptionsJson(modelDefinition, role)),
+		modelDefinition.extraIdentifier
+			? eq(modelVersionTable.extraIdentifier, modelDefinition.extraIdentifier)
+			: isNull(modelVersionTable.extraIdentifier)
+	) as SQL
+
+export const getModelDefinitionForVersion = (
+	registry: FileBackedModelRegistry,
+	row: ModelVersionIdentityRow
+) =>
+	registry.modelsByRuntimeIdentity.get(
+		getModelRuntimeIdentityKeyFromParts({
+			provider: row.providerCode,
+			providerModelCode: row.modelVersionCode,
+			extraIdentifier: row.modelVersionExtraIdentifier,
+			runtimeOptionsJson: row.modelVersionRuntimeOptionsJson,
+		})
+	)
+
+export const getModelVersionLabel = (registry: FileBackedModelRegistry, row: ModelVersionIdentityRow) =>
+	getModelDefinitionForVersion(registry, row)?.id ??
+	getModelRuntimeIdentityKeyFromParts({
+		provider: row.providerCode,
+		providerModelCode: row.modelVersionCode,
+		extraIdentifier: row.modelVersionExtraIdentifier,
+		runtimeOptionsJson: row.modelVersionRuntimeOptionsJson,
+	})

--- a/src/main/providers.ts
+++ b/src/main/providers.ts
@@ -7,7 +7,8 @@ import { currencies, modelCosts } from '../database/schema/costs.js'
 import { sessionEvaluations, sessions } from '../database/schema/sessions.js'
 import {
 	clearFileBackedModelRegistryCache,
-	getModelRuntimeOptionsJson,
+	getModelRuntimeIdentityKeys,
+	getModelRuntimeIdentities,
 	loadFileBackedModelRegistry,
 	type FileBackedModelRegistry,
 	type ModelDefinition,
@@ -16,10 +17,6 @@ import {
 import { isCurrencyRegistryConfigured, validateCurrencyRegistryReferences } from '../config/currency-registry.js'
 
 type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
-
-const getModelIdentityKey = (
-	model: Pick<ModelDefinition, 'provider' | 'providerModelCode' | 'extraIdentifier' | 'providerOptions' | 'thinking'>
-) => `${model.provider}:${model.providerModelCode}:${model.extraIdentifier ?? ''}:${getModelRuntimeOptionsJson(model)}`
 
 const setActiveByIds = async (tx: Transaction, table: typeof providers | typeof models | typeof modelVersions, ids: number[]) => {
 	await tx.update(table).set({ active: false })
@@ -190,13 +187,14 @@ const upsertModelVersion = async (
 	tx: Transaction,
 	providerId: number,
 	modelId: number,
-	modelConfig: ModelDefinition
+	modelConfig: ModelDefinition,
+	runtimeOptionsJson: string
 ) => {
 	let modelVersion = await tx.query.modelVersions.findFirst({
 		where: and(
 				eq(modelVersions.providerId, providerId),
 				eq(modelVersions.providerModelCode, modelConfig.providerModelCode),
-				eq(modelVersions.runtimeOptionsJson, getModelRuntimeOptionsJson(modelConfig)),
+				eq(modelVersions.runtimeOptionsJson, runtimeOptionsJson),
 				modelConfig.extraIdentifier
 					? eq(modelVersions.extraIdentifier, modelConfig.extraIdentifier)
 					: isNull(modelVersions.extraIdentifier)
@@ -220,7 +218,7 @@ const upsertModelVersion = async (
 					providerId,
 					providerModelCode: modelConfig.providerModelCode,
 					extraIdentifier: modelConfig.extraIdentifier,
-					runtimeOptionsJson: getModelRuntimeOptionsJson(modelConfig),
+					runtimeOptionsJson,
 					active: true,
 				})
 			.returning()
@@ -257,7 +255,8 @@ const syncRegistryToDb = async (registry: FileBackedModelRegistry) => {
 		}
 
 		const activeModelVersionIds = new Set<number>()
-		const activeModelIdentityKeys = new Set(registry.activeModels.map(model => getModelIdentityKey(model)))
+		const syncedCostModelVersionIds = new Set<number>()
+		const activeModelIdentityKeys = new Set(registry.activeModels.flatMap(model => getModelRuntimeIdentityKeys(model)))
 		for (const modelConfig of registry.models) {
 			const provider = providersByCode.get(modelConfig.provider)
 			const model = modelsByCode.get(modelConfig.code)
@@ -266,10 +265,15 @@ const syncRegistryToDb = async (registry: FileBackedModelRegistry) => {
 				throw new Error(`Failed to resolve registry entry ${modelConfig.provider}:${modelConfig.providerModelCode}`)
 			}
 
-			const modelVersion = await upsertModelVersion(tx, provider.id, model.id, modelConfig)
-			if (activeModelIdentityKeys.has(getModelIdentityKey(modelConfig))) {
-				activeModelVersionIds.add(modelVersion.id)
-				await syncModelCostsFromYaml(tx, modelVersion.id, modelConfig)
+			for (const identity of getModelRuntimeIdentities(modelConfig)) {
+				const modelVersion = await upsertModelVersion(tx, provider.id, model.id, modelConfig, identity.runtimeOptionsJson)
+				if (activeModelIdentityKeys.has(identity.key)) {
+					activeModelVersionIds.add(modelVersion.id)
+					if (!syncedCostModelVersionIds.has(modelVersion.id)) {
+						await syncModelCostsFromYaml(tx, modelVersion.id, modelConfig)
+						syncedCostModelVersionIds.add(modelVersion.id)
+					}
+				}
 			}
 		}
 

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -2,7 +2,7 @@
  * This module is responsible for running all test sessions that have not been run yet.
  */
 
-import { and, or, eq, ne, inArray, sql, lt, countDistinct } from 'drizzle-orm'
+import { and, or, eq, not, inArray, sql, lt, countDistinct } from 'drizzle-orm'
 import {
 	generateText,
 	jsonSchema,
@@ -25,6 +25,12 @@ import {
 	type CapabilityRequirements,
 } from './capabilities.js'
 import { refreshSessionTokenLimitState } from './token-limits.js'
+import {
+	getConfiguredModelDefinition,
+	getModelDefinitionForVersion,
+	getModelVersionLabel,
+	modelVersionMatchesDefinition,
+} from './model-definition-filters.js'
 
 /**
  * Logs the number of skipped tests based on the current attempt and total attempts.
@@ -96,11 +102,15 @@ const getMissingTests = async (
 		testToToolVersionRels,
 	} = schema
 
-	const modelConfigsWithTemperature = testsConfig.candidates.filter(candidate => candidate.temperature !== undefined)
-	const modelConfigsWithTags = testsConfig.candidates.filter(
+	const candidatesWithDefinitions = testsConfig.candidates.map(candidate => ({
+		...candidate,
+		modelDefinition: getConfiguredModelDefinition(registry, candidate),
+	}))
+	const modelConfigsWithTemperature = candidatesWithDefinitions.filter(candidate => candidate.temperature !== undefined)
+	const modelConfigsWithTags = candidatesWithDefinitions.filter(
 		candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0
 	)
-	const modelConfigsWithProhibitedTags = testsConfig.candidates.filter(
+	const modelConfigsWithProhibitedTags = candidatesWithDefinitions.filter(
 		candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0
 	)
 
@@ -108,6 +118,8 @@ const getMissingTests = async (
 		.select({
 			modelVersionId: modelVersions.id,
 			modelVersionCode: modelVersions.providerModelCode,
+			modelVersionExtraIdentifier: modelVersions.extraIdentifier,
+			modelVersionRuntimeOptionsJson: modelVersions.runtimeOptionsJson,
 			providerCode: providers.code,
 			testVersionId: testVersions.id,
 			testContent: testVersions.content,
@@ -134,11 +146,7 @@ const getMissingTests = async (
 			and(
 				eq(providers.id, modelVersions.providerId),
 				eq(providers.active, true),
-				or(
-					...testsConfig.candidates.map(({ provider, model }) =>
-						and(eq(providers.code, provider), eq(modelVersions.providerModelCode, model))
-					)
-				)
+				or(...candidatesWithDefinitions.map(candidate => modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')))
 			)
 		)
 
@@ -168,14 +176,13 @@ const getMissingTests = async (
 				modelConfigsWithTemperature.length > 0
 					? sql`${sessions.temperature} = CASE
 								${sql.join(
-									modelConfigsWithTemperature.map(
-										candidate =>
-											sql`WHEN
-												${eq(modelVersions.providerModelCode, candidate.model)}
-												AND ${eq(providers.code, candidate.provider)}
+								modelConfigsWithTemperature.map(
+									candidate =>
+										sql`WHEN
+												${modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')}
 												THEN ${candidate.temperature}`
-									)
-								)}
+								)
+							)}
 								ELSE ${testsConfig.candidatesTemperature}
 							END`
 					: eq(sessions.temperature, testsConfig.candidatesTemperature)
@@ -211,8 +218,7 @@ const getMissingTests = async (
 						? modelConfigsWithTags.map(
 								candidate =>
 									sql`sum(CASE WHEN ${or(
-										ne(modelVersions.providerModelCode, candidate.model),
-										ne(providers.code, candidate.provider),
+										not(modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')),
 										inArray(tags.name, candidate.requiredTags!)
 									)} THEN 1 ELSE 0 END) > 0`
 						  )
@@ -223,8 +229,7 @@ const getMissingTests = async (
 						? modelConfigsWithProhibitedTags.map(
 								candidate =>
 									sql`sum(CASE WHEN ${and(
-										eq(modelVersions.providerModelCode, candidate.model),
-										eq(providers.code, candidate.provider),
+										modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate'),
 										inArray(tags.name, candidate.prohibitedTags!)
 									)} THEN 1 ELSE 0 END) = 0`
 						  )
@@ -239,8 +244,8 @@ const getMissingTests = async (
 
 	const warnedModelReferences = new Set<string>()
 	return missingTests.filter(test => {
-		const modelReference = `${test.providerCode}:${test.modelVersionCode}`
-		const modelDefinition = registry.modelsByReference.get(modelReference)
+		const modelReference = getModelVersionLabel(registry, test)
+		const modelDefinition = getModelDefinitionForVersion(registry, test)
 		const files = getReferencedFiles(test.testContent, envConfig.AI_TESTER_TESTS_DIR)
 		const outputRequirements: CapabilityRequirements['output'] = test.structuredObjectSchema
 			? ['structured']
@@ -282,7 +287,7 @@ export const runAllTestsWithDeps = async ({
 	const missingTests = await getMissingTests(db, testsConfig, registry, envConfig)
 	const modelConfigsWithTemperature = testsConfig.candidates.filter(candidate => candidate.temperature !== undefined)
 	const modelsWithTemperatures = new Map<string, number>(
-		modelConfigsWithTemperature.map(({ provider, model, temperature }) => [`${provider}:${model}`, temperature!])
+		modelConfigsWithTemperature.map(({ id, temperature }) => [id, temperature!])
 	)
 
 	// The total number of missing tests needs to account for the number of attempts
@@ -303,11 +308,10 @@ export const runAllTestsWithDeps = async ({
 	for (const test of missingTests) {
 		const provider = getProvider(test.providerCode)
 		if (!provider) throw new Error(`Provider ${test.providerCode} not found`)
-		const modelDefinition = registry.modelsByReference.get(`${test.providerCode}:${test.modelVersionCode}`)
+		const modelDefinition = getModelDefinitionForVersion(registry, test)
 		const model = wrapModel(provider(test.modelVersionCode), 'candidate', modelDefinition)
 
-		const temperature =
-			modelsWithTemperatures.get(`${test.providerCode}:${test.modelVersionCode}`) ?? testsConfig.candidatesTemperature
+		const temperature = (modelDefinition ? modelsWithTemperatures.get(modelDefinition.id) : undefined) ?? testsConfig.candidatesTemperature
 
 		// We extract the array of messages
 		const sections = getSectionsFromMarkdownContent(test.testContent)

--- a/src/main/stats.ts
+++ b/src/main/stats.ts
@@ -1,9 +1,15 @@
-import { and, or, eq, ne, inArray, sql, countDistinct, desc, aliasedTable } from 'drizzle-orm'
+import { and, or, eq, not, inArray, sql, countDistinct, desc, aliasedTable } from 'drizzle-orm'
 
 import { schema } from '../database/schema.js'
 import { type AnalysisQuery } from '../config/index.js'
 import { db } from '../database/db.js'
 import { sessionEvaluations } from '../database/schema/sessions.js'
+import { getFileBackedModelRegistry } from '../config/model-registry.js'
+import {
+	getConfiguredModelDefinition,
+	getModelVersionLabel,
+	modelVersionMatchesDefinition,
+} from './model-definition-filters.js'
 
 /** Locale to use for currency formatting, determined by the JS runtime */
 const LOCALE = navigator.language ?? 'en-US'
@@ -13,6 +19,7 @@ const EXTRA_FRACTION_DIGITS = 2
 
 export const showStats = async (query: AnalysisQuery) => {
 	console.log('Checking for stats...')
+	const registry = getFileBackedModelRegistry()
 
 	if (query.candidates && query.candidates.length === 0) {
 		console.log(`⚠️ Query "${query.description}" has no active candidate models.`)
@@ -24,23 +31,31 @@ export const showStats = async (query: AnalysisQuery) => {
 		return
 	}
 
+	const candidatesWithDefinitions = query.candidates?.map(candidate => ({
+		...candidate,
+		modelDefinition: getConfiguredModelDefinition(registry, candidate),
+	}))
+	const evaluatorsWithDefinitions = query.evaluators?.map(evaluator => ({
+		...evaluator,
+		modelDefinition: getConfiguredModelDefinition(registry, evaluator),
+	}))
 	const candidateModelConfigsWithTemperature =
-		query.candidates?.filter(candidate => candidate.temperature !== undefined) ?? []
+		candidatesWithDefinitions?.filter(candidate => candidate.temperature !== undefined) ?? []
 	const modelConfigsWithTags =
-		query.candidates?.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0) ??
+		candidatesWithDefinitions?.filter(candidate => candidate.requiredTags !== undefined && candidate.requiredTags.length > 0) ??
 		[]
 	const modelConfigsWithProhibitedTags =
-		query.candidates?.filter(
+		candidatesWithDefinitions?.filter(
 			candidate => candidate.prohibitedTags !== undefined && candidate.prohibitedTags.length > 0
 		) ?? []
 
 	const evaluatorModelConfigsWithTemperature =
-		query.evaluators?.filter(evaluator => evaluator.temperature !== undefined) ?? []
+		evaluatorsWithDefinitions?.filter(evaluator => evaluator.temperature !== undefined) ?? []
 	const evaluatorModelConfigsWithTags =
-		query.evaluators?.filter(evaluator => evaluator.requiredTags !== undefined && evaluator.requiredTags.length > 0) ??
+		evaluatorsWithDefinitions?.filter(evaluator => evaluator.requiredTags !== undefined && evaluator.requiredTags.length > 0) ??
 		[]
 	const evaluatorModelConfigsWithProhibitedTags =
-		query.evaluators?.filter(
+		evaluatorsWithDefinitions?.filter(
 			evaluator => evaluator.prohibitedTags !== undefined && evaluator.prohibitedTags.length > 0
 		) ?? []
 	const systemPromptRefs = query.systemPrompts ?? []
@@ -74,6 +89,8 @@ export const showStats = async (query: AnalysisQuery) => {
 			.select({
 				testVersionId: testVersions.id,
 				modelVersionCode: modelVersions.providerModelCode,
+				modelVersionExtraIdentifier: modelVersions.extraIdentifier,
+				modelVersionRuntimeOptionsJson: modelVersions.runtimeOptionsJson,
 				providerCode: providers.code,
 
 				// Drizzle-ORM doesn't auto-alias columns, and does not support aliasing columns manually, so we have to use the raw SQL
@@ -108,8 +125,7 @@ export const showStats = async (query: AnalysisQuery) => {
 								evaluatorModelConfigsWithTemperature.map(
 									evaluator =>
 										sql`WHEN
-											${eq(evaluatorModelVersionAlias.providerModelCode, evaluator.model)}
-											AND ${eq(evaluatorProviderAlias.code, evaluator.provider)}
+											${modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator')}
 											THEN ${evaluator.temperature}`
 								)
 							)}
@@ -123,11 +139,11 @@ export const showStats = async (query: AnalysisQuery) => {
 				and(
 					eq(sessions.modelVersionId, modelVersions.id),
 					eq(modelVersions.active, true),
-					...(query.candidates
+					...(candidatesWithDefinitions
 						? [
 								or(
-									...query.candidates.map(({ provider, model }) =>
-										and(eq(providers.code, provider), eq(modelVersions.providerModelCode, model))
+									...candidatesWithDefinitions.map(candidate =>
+										modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')
 									)
 								),
 						  ]
@@ -140,11 +156,11 @@ export const showStats = async (query: AnalysisQuery) => {
 				and(
 					eq(sessionEvaluations.modelVersionId, evaluatorModelVersionAlias.id),
 					eq(evaluatorModelVersionAlias.active, true),
-					...(query.evaluators
+					...(evaluatorsWithDefinitions
 						? [
 								or(
-									...query.evaluators.map(({ provider, model }) =>
-										and(eq(evaluatorProviderAlias.code, provider), eq(evaluatorModelVersionAlias.providerModelCode, model))
+									...evaluatorsWithDefinitions.map(evaluator =>
+										modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator')
 									)
 								),
 						  ]
@@ -174,8 +190,7 @@ export const showStats = async (query: AnalysisQuery) => {
 								candidateModelConfigsWithTemperature.map(
 									candidate =>
 										sql`WHEN
-											${eq(modelVersions.providerModelCode, candidate.model)}
-											AND ${eq(providers.code, candidate.provider)}
+											${modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')}
 											THEN ${candidate.temperature}`
 								)
 							)}
@@ -215,8 +230,7 @@ export const showStats = async (query: AnalysisQuery) => {
 							? modelConfigsWithTags.map(
 									candidate =>
 										sql`sum(CASE WHEN ${or(
-											ne(modelVersions.providerModelCode, candidate.model),
-											ne(providers.code, candidate.provider),
+											not(modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate')),
 											inArray(tags.name, candidate.requiredTags!)
 										)} THEN 1 ELSE 0 END) > 0`
 							  )
@@ -227,8 +241,7 @@ export const showStats = async (query: AnalysisQuery) => {
 							? modelConfigsWithProhibitedTags.map(
 									candidate =>
 										sql`sum(CASE WHEN ${and(
-											eq(modelVersions.providerModelCode, candidate.model),
-											eq(providers.code, candidate.provider),
+											modelVersionMatchesDefinition(providers, modelVersions, candidate.modelDefinition, 'candidate'),
 											inArray(tags.name, candidate.prohibitedTags!)
 										)} THEN 1 ELSE 0 END) = 0`
 							  )
@@ -239,8 +252,7 @@ export const showStats = async (query: AnalysisQuery) => {
 							? evaluatorModelConfigsWithTags.map(
 									evaluator =>
 										sql`sum(CASE WHEN ${or(
-											ne(evaluatorModelVersionAlias.providerModelCode, evaluator.model),
-											ne(evaluatorProviderAlias.code, evaluator.provider),
+											not(modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator')),
 											inArray(tags.name, evaluator.requiredTags!)
 										)} THEN 1 ELSE 0 END) > 0`
 							  )
@@ -251,8 +263,7 @@ export const showStats = async (query: AnalysisQuery) => {
 							? evaluatorModelConfigsWithProhibitedTags.map(
 									evaluator =>
 										sql`sum(CASE WHEN ${and(
-											eq(evaluatorModelVersionAlias.providerModelCode, evaluator.model),
-											eq(evaluatorProviderAlias.code, evaluator.provider),
+											modelVersionMatchesDefinition(evaluatorProviderAlias, evaluatorModelVersionAlias, evaluator.modelDefinition, 'evaluator'),
 											inArray(tags.name, evaluator.prohibitedTags!)
 										)} THEN 1 ELSE 0 END) = 0`
 							  )
@@ -320,6 +331,8 @@ export const showStats = async (query: AnalysisQuery) => {
 			testsCount: countDistinct(cte.testVersionId),
 			evalsCount: sql<number>`SUM(${cte.evalsCount})`,
 			modelVersionCode: cte.modelVersionCode,
+			modelVersionExtraIdentifier: cte.modelVersionExtraIdentifier,
+			modelVersionRuntimeOptionsJson: cte.modelVersionRuntimeOptionsJson,
 			providerCode: cte.providerCode,
 			passRate: passRateQuery,
 			costPerSession: costPerSessionQuery.as('costPerSession'),
@@ -354,7 +367,7 @@ export const showStats = async (query: AnalysisQuery) => {
 		Object.fromEntries(
 			stats.map(result => {
 				return [
-					result.modelVersionCode,
+					getModelVersionLabel(registry, result),
 					{
 						Provider: result.providerCode,
 						'✅%': Number((result.passRate * 100).toFixed(0)),

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -308,7 +308,7 @@ test('cli list prints file-backed values for runtime overrides without an existi
 
 	assert.strictEqual(output.result.exitCode, 0)
 	const text = String(output.logs[0]?.[0])
-	assert.match(text, /Models:\n  {"provider":"openai","model":"gpt-4o-mini-2024-07-18"}/)
+	assert.match(text, /Models:\n  {"id":"openai\/gpt-4o-mini-2024-07-18"}/)
 	assert.doesNotMatch(text, /gemma2:9b/)
 	assert.match(text, /Tags:\n  lang_en\n  reasoning\n  smoke/)
 	assert.match(text, /Prompts:\n  concise\n  helpful/)
@@ -629,8 +629,7 @@ test('cli stats --list prints configured analysis query descriptions in order', 
 			'  - description: Hidden query',
 			'    currency: USD',
 			'    candidates:',
-			'      - provider: missing',
-			'        model: missing',
+			'      - id: missing/missing',
 			'  - description: Second query',
 			'    currency: USD',
 		].join('\n')
@@ -911,7 +910,7 @@ test('cli stats --dry-run suppresses unavailable model warnings for ad hoc queri
 				'--query-json',
 				JSON.stringify({
 					currency: 'USD',
-					candidates: [{ provider: 'missing', model: 'missing' }],
+					candidates: [{ id: 'missing/missing' }],
 				}),
 			],
 		})
@@ -1128,8 +1127,8 @@ test('cli run-tests runtime overrides filter unavailable model references', asyn
 				'--config-overrides',
 				JSON.stringify({
 					candidates: [
-						{ provider: 'openai', model: 'gpt-4o-mini' },
-						{ provider: 'openai', model: 'missing-model' },
+						{ id: 'openai/gpt-4o-mini' },
+						{ id: 'openai/missing-model' },
 					],
 				}),
 			],
@@ -1148,9 +1147,9 @@ test('cli run-tests runtime overrides filter unavailable model references', asyn
 		String(entry[0]).startsWith('Dry run: resolved test run configuration:')
 	)
 	const resolvedConfig = JSON.parse(String(resolvedLog?.[0]).split('\n').slice(1).join('\n')) as {
-		candidates: Array<{ provider: string; model: string }>
+		candidates: Array<{ id: string }>
 	}
-	assert.deepStrictEqual(resolvedConfig.candidates, [{ provider: 'openai', model: 'gpt-4o-mini' }])
+	assert.deepStrictEqual(resolvedConfig.candidates, [{ id: 'openai/gpt-4o-mini' }])
 })
 
 test('run-tests confirmation cancellation happens before runtime config parsing', async t => {

--- a/tests/config-validation.test.ts
+++ b/tests/config-validation.test.ts
@@ -46,10 +46,8 @@ test('config loading rejects duplicate configured model references', async t => 
 		[
 			'candidatesTemperature: 0.3',
 			'candidates:',
-			'  - provider: openai',
-			'    model: gpt-4o-mini',
-			'  - provider: openai',
-			'    model: gpt-4o-mini',
+			'  - id: openai/gpt-4o-mini',
+			'  - id: openai/gpt-4o-mini',
 			'attempts: 1',
 			'requiredTags1: []',
 			'requiredTags2: []',
@@ -61,6 +59,31 @@ test('config loading rejects duplicate configured model references', async t => 
 	)
 
 	expectModuleFailure(env.runModule('config:getResolvedTestsConfig'), /Duplicate configured model reference/)
+})
+
+test('config loading rejects empty configured model ids', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	await env.write(
+		'ai-tester.config.yaml',
+		[
+			'candidatesTemperature: 0.3',
+			'candidates:',
+			'  - id: ""',
+			'attempts: 1',
+			'requiredTags1: []',
+			'requiredTags2: []',
+			'prohibitedTags: []',
+			'evaluators: []',
+			'evaluatorsTemperature: 0.4',
+			'evaluationsPerEvaluator: 1',
+		].join('\n')
+	)
+
+	expectModuleFailure(env.runModule('config:getResolvedTestsConfig'), /String must contain at least 1 character/)
 })
 
 test('config loading rejects duplicate analysis query descriptions', async t => {
@@ -119,19 +142,15 @@ test('resolveTestsConfig filters unavailable configured models from tests and an
 		[
 			'candidatesTemperature: 0.3',
 			'candidates:',
-			'  - provider: openai',
-			'    model: gpt-4o-mini',
-			'  - provider: openai',
-			'    model: missing-candidate',
+			'  - id: openai/gpt-4o-mini',
+			'  - id: openai/missing-candidate',
 			'attempts: 1',
 			'requiredTags1: []',
 			'requiredTags2: []',
 			'prohibitedTags: []',
 			'evaluators:',
-			'  - provider: openai',
-			'    model: gpt-4o-mini',
-			'  - provider: openai',
-			'    model: missing-evaluator',
+			'  - id: openai/gpt-4o-mini',
+			'  - id: openai/missing-evaluator',
 			'evaluatorsTemperature: 0.4',
 			'evaluationsPerEvaluator: 1',
 			'analysisQueries:',
@@ -141,13 +160,10 @@ test('resolveTestsConfig filters unavailable configured models from tests and an
 			'      - helpful',
 			'      - helpful-v1-hash',
 			'    candidates:',
-			'      - provider: openai',
-			'        model: gpt-4o-mini',
-			'      - provider: openai',
-			'        model: missing-analysis-candidate',
+			'      - id: openai/gpt-4o-mini',
+			'      - id: openai/missing-analysis-candidate',
 			'    evaluators:',
-			'      - provider: openai',
-			'        model: missing-analysis-evaluator',
+			'      - id: openai/missing-analysis-evaluator',
 		].join('\n')
 	)
 	await env.write(
@@ -157,20 +173,20 @@ test('resolveTestsConfig filters unavailable configured models from tests and an
 
 	const result = expectModuleSuccess(env.runModule('config:getResolvedTestsConfig')) as {
 		resolvedTestsConfig: {
-			candidates: Array<{ provider: string; model: string }>
-			evaluators: Array<{ provider: string; model: string }>
+			candidates: Array<{ id: string }>
+			evaluators: Array<{ id: string }>
 			analysisQueries?: Array<{
 				systemPrompts?: string[]
-				candidates?: Array<{ provider: string; model: string }>
-				evaluators?: Array<{ provider: string; model: string }>
+				candidates?: Array<{ id: string }>
+				evaluators?: Array<{ id: string }>
 			}>
 		}
 	}
 
-	assert.deepStrictEqual(result.resolvedTestsConfig.candidates, [{ provider: 'openai', model: 'gpt-4o-mini' }])
-	assert.deepStrictEqual(result.resolvedTestsConfig.evaluators, [{ provider: 'openai', model: 'gpt-4o-mini' }])
+	assert.deepStrictEqual(result.resolvedTestsConfig.candidates, [{ id: 'openai/gpt-4o-mini' }])
+	assert.deepStrictEqual(result.resolvedTestsConfig.evaluators, [{ id: 'openai/gpt-4o-mini' }])
 	assert.deepStrictEqual(result.resolvedTestsConfig.analysisQueries?.[0]?.candidates, [
-		{ provider: 'openai', model: 'gpt-4o-mini' },
+		{ id: 'openai/gpt-4o-mini' },
 	])
 	assert.deepStrictEqual(result.resolvedTestsConfig.analysisQueries?.[0]?.systemPrompts, [
 		'helpful',
@@ -275,6 +291,7 @@ test('model registry rejects duplicate runtime identities across YAML entries', 
 		'data/models/a.yaml',
 		[
 			'code: gpt-4o-mini-a',
+			'id: openai/gpt-4o-mini/a',
 			'provider: openai',
 			'providerModelCode: gpt-4o-mini',
 			'providerOptions:',
@@ -285,6 +302,7 @@ test('model registry rejects duplicate runtime identities across YAML entries', 
 		'data/models/b.yaml',
 		[
 			'code: gpt-4o-mini-b',
+			'id: openai/gpt-4o-mini/b',
 			'provider: openai',
 			'providerModelCode: gpt-4o-mini',
 			'providerOptions:',
@@ -295,7 +313,7 @@ test('model registry rejects duplicate runtime identities across YAML entries', 
 	expectModuleFailure(env.runModule('modelRegistry:loadModels'), /Duplicate runtime model identity found in YAML files/)
 })
 
-test('model registry rejects conflicting active variants for the same provider model code', async t => {
+test('model registry rejects duplicate active model ids across YAML entries', async t => {
 	const env = await createSyncTestEnv()
 	t.after(async () => {
 		await env.cleanup()
@@ -306,6 +324,7 @@ test('model registry rejects conflicting active variants for the same provider m
 		'data/models/a.yaml',
 		[
 			'code: gpt-4o-mini-a',
+			'id: openai/gpt-4o-mini/shared',
 			'provider: openai',
 			'providerModelCode: gpt-4o-mini',
 			'providerOptions:',
@@ -316,6 +335,7 @@ test('model registry rejects conflicting active variants for the same provider m
 		'data/models/b.yaml',
 		[
 			'code: gpt-4o-mini-b',
+			'id: openai/gpt-4o-mini/shared',
 			'provider: openai',
 			'providerModelCode: gpt-4o-mini',
 			'providerOptions:',
@@ -323,7 +343,103 @@ test('model registry rejects conflicting active variants for the same provider m
 		].join('\n')
 	)
 
-	expectModuleFailure(env.runModule('modelRegistry:loadRegistry'), /Conflicting active model variants for openai:gpt-4o-mini/)
+	expectModuleFailure(env.runModule('modelRegistry:loadModels'), /Duplicate active model id found in YAML files/)
+})
+
+test('model registry allows inactive legacy entries with the same derived default id', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	await env.write('data/providers/openai.yaml', ['code: openai', 'name: OpenAI', 'type: openai'].join('\n'))
+	await env.write(
+		'data/models/a.yaml',
+		[
+			'code: gpt-4o-mini-a',
+			'active: false',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'providerOptions:',
+			'  seed: 1',
+		].join('\n')
+	)
+	await env.write(
+		'data/models/b.yaml',
+		[
+			'code: gpt-4o-mini-b',
+			'active: false',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'providerOptions:',
+			'  seed: 2',
+		].join('\n')
+	)
+
+	const models = expectModuleSuccess(env.runModule('modelRegistry:loadModels')) as Array<{ id: string }>
+	assert.deepStrictEqual(
+		models.map(model => model.id),
+		['openai/gpt-4o-mini', 'openai/gpt-4o-mini']
+	)
+})
+
+test('model registry rejects unique property paths resolved through object prototypes', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	await env.write('data/providers/openai.yaml', ['code: openai', 'name: OpenAI', 'type: openai'].join('\n'))
+	await env.write(
+		'data/models/gpt-4o-mini.yaml',
+		[
+			'code: gpt-4o-mini',
+			'id: openai/gpt-4o-mini/prototype',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'uniqueProperties:',
+			'  - providerOptions.constructor',
+			'providerOptions: {}',
+		].join('\n')
+	)
+
+	expectModuleFailure(
+		env.runModule('modelRegistry:loadModels'),
+		/declares uniqueProperties path providerOptions\.constructor, but that value is not set/
+	)
+})
+
+test('model registry rejects active variants without declared unique properties', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	await env.write('data/providers/openai.yaml', ['code: openai', 'name: OpenAI', 'type: openai'].join('\n'))
+	await env.write(
+		'data/models/a.yaml',
+		[
+			'code: gpt-4o-mini-a',
+			'id: openai/gpt-4o-mini/a',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'providerOptions:',
+			'  seed: 1',
+		].join('\n')
+	)
+	await env.write(
+		'data/models/b.yaml',
+		[
+			'code: gpt-4o-mini-b',
+			'id: openai/gpt-4o-mini/b',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'providerOptions:',
+			'  seed: 2',
+		].join('\n')
+	)
+
+	expectModuleFailure(env.runModule('modelRegistry:loadRegistry'), /must declare uniqueProperties/)
 })
 
 test('model registry loads capabilities and defaults missing capability keys to false', async t => {

--- a/tests/evaluations.test.ts
+++ b/tests/evaluations.test.ts
@@ -13,13 +13,13 @@ import {
 } from './helpers/test-harness.js'
 
 const baseTestsConfig = (candidateProvider: string, candidateModel: string, evaluatorProvider: string, evaluatorModel: string) => ({
-	candidates: [{ provider: candidateProvider, model: candidateModel }],
+	candidates: [{ id: `${candidateProvider}/${candidateModel}` }],
 	candidatesTemperature: 0.3,
 	attempts: 1,
 	requiredTags1: [] as string[],
 	requiredTags2: [] as string[],
 	prohibitedTags: [] as string[],
-	evaluators: [{ provider: evaluatorProvider, model: evaluatorModel }],
+	evaluators: [{ id: `${evaluatorProvider}/${evaluatorModel}` }],
 	evaluatorsTemperature: 0.4,
 	evaluationsPerEvaluator: 1,
 	analysisQueries: undefined,
@@ -59,7 +59,19 @@ const createDeps = (
 ) => ({
 	db,
 	testsConfig: baseTestsConfig(candidateProviderCode, candidateModelCode, evaluatorProviderCode, evaluatorModelCode),
-	registry: createRegistry(registryModel as never),
+	registry: createRegistry(
+		{
+			provider: candidateProviderCode,
+			providerModelCode: candidateModelCode,
+			providerOptions: {},
+			thinking: undefined,
+			capabilities: {
+				input: { text: true, image: true, file: true, pdf: true },
+				output: { text: true, structured: true, tools: true, reasoning: true },
+			},
+		},
+		registryModel as never
+	),
 	confirmRun: async () => true,
 	getProvider: (code: string) =>
 		code === evaluatorProviderCode

--- a/tests/file-sync.test.ts
+++ b/tests/file-sync.test.ts
@@ -131,6 +131,172 @@ test('provider and currency sync bootstraps empty DB and creates a new active mo
 	assert.deepStrictEqual(activeCosts, [{ currencyCode: 'JPY', costPerPromptToken: 0.3 }])
 })
 
+test('provider sync allows multiple active model definitions for the same provider model when unique properties differ', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	await env.write('data/providers/openai.yaml', ['code: openai', 'name: OpenAI', 'type: openai'].join('\n'))
+	await env.write(
+		'data/currencies/USD.yaml',
+		['code: USD', 'rates:', '  - rateInUSD: 1', '    validFrom: 2025-01-01'].join('\n')
+	)
+	await env.write(
+		'data/models/gpt-4o-mini-low.yaml',
+		[
+			'id: openai/gpt-4o-mini/reasoning-low',
+			'code: gpt-4o-mini',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'uniqueProperties:',
+			'  - thinking.effort',
+			'thinking:',
+			'  effort: low',
+			'costs:',
+			'  - costPerCall: 0',
+			'    costPerPromptToken: 0.1',
+			'    costPerCompletionToken: 0.2',
+			'    costPerHour: 0',
+			'    currency: USD',
+			'    validFrom: 2025-01-01',
+		].join('\n')
+	)
+	await env.write(
+		'data/models/gpt-4o-mini-high.yaml',
+		[
+			'id: openai/gpt-4o-mini/reasoning-high',
+			'code: gpt-4o-mini',
+			'provider: openai',
+			'providerModelCode: gpt-4o-mini',
+			'uniqueProperties:',
+			'  - thinking.effort',
+			'thinking:',
+			'  effort: high',
+			'costs:',
+			'  - costPerCall: 0',
+			'    costPerPromptToken: 0.1',
+			'    costPerCompletionToken: 0.2',
+			'    costPerHour: 0',
+			'    currency: USD',
+			'    validFrom: 2025-01-01',
+		].join('\n')
+	)
+
+	expectSyncSuccess(env.runSync(['currencies', 'providers']))
+
+	const models = await env.db.select().from(schema.models)
+	const modelVersions = await env.db.select().from(schema.modelVersions)
+	assert.strictEqual(models.length, 1)
+	assert.strictEqual(modelVersions.length, 2)
+	assert.strictEqual(modelVersions.filter(version => version.active).length, 2)
+	assert.ok(modelVersions.some(version => version.runtimeOptionsJson.includes('"effort":"low"')))
+	assert.ok(modelVersions.some(version => version.runtimeOptionsJson.includes('"effort":"high"')))
+})
+
+test('provider sync does not create a new model version when only a YAML id is added', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	const modelWithoutId = [
+		'code: gpt-4o-mini',
+		'provider: openai',
+		'providerModelCode: gpt-4o-mini',
+		'providerOptions:',
+		'  seed: 1',
+		'costs:',
+		'  - costPerCall: 0',
+		'    costPerPromptToken: 0.1',
+		'    costPerCompletionToken: 0.2',
+		'    costPerHour: 0',
+		'    currency: USD',
+		'    validFrom: 2025-01-01',
+	].join('\n')
+
+	await env.write('data/providers/openai.yaml', ['code: openai', 'name: OpenAI', 'type: openai'].join('\n'))
+	await env.write(
+		'data/currencies/USD.yaml',
+		['code: USD', 'rates:', '  - rateInUSD: 1', '    validFrom: 2025-01-01'].join('\n')
+	)
+	await env.write('data/models/gpt-4o-mini.yaml', modelWithoutId)
+
+	expectSyncSuccess(env.runSync(['currencies', 'providers']))
+
+	const [firstVersion] = await env.db.select().from(schema.modelVersions)
+	assert.ok(firstVersion)
+
+	await env.write('data/models/gpt-4o-mini.yaml', ['id: openai/gpt-4o-mini/default', modelWithoutId].join('\n'))
+
+	expectSyncSuccess(env.runSync(['currencies', 'providers']))
+
+	const modelVersions = await env.db.select().from(schema.modelVersions)
+	assert.strictEqual(modelVersions.length, 1)
+	assert.strictEqual(modelVersions[0]?.id, firstVersion!.id)
+	assert.strictEqual(modelVersions[0]?.active, true)
+})
+
+test('provider sync keeps role-specific model versions tied to effective runtime options', async t => {
+	const env = await createSyncTestEnv()
+	t.after(async () => {
+		await env.cleanup()
+	})
+
+	const writeModel = async (evaluatorLane: string) => {
+		await env.write(
+			'data/models/gpt-4o-mini.yaml',
+			[
+				'id: openai/gpt-4o-mini/role-overrides',
+				'code: gpt-4o-mini',
+				'provider: openai',
+				'providerModelCode: gpt-4o-mini',
+				'candidateOverrides:',
+				'  providerOptions:',
+				'    user: candidate',
+				'evaluatorOverrides:',
+				'  providerOptions:',
+				`    lane: ${evaluatorLane}`,
+				'costs:',
+				'  - costPerCall: 0',
+				'    costPerPromptToken: 0.1',
+				'    costPerCompletionToken: 0.2',
+				'    costPerHour: 0',
+				'    currency: USD',
+				'    validFrom: 2025-01-01',
+			].join('\n')
+		)
+	}
+
+	await env.write('data/providers/openai.yaml', ['code: openai', 'name: OpenAI', 'type: openai'].join('\n'))
+	await env.write(
+		'data/currencies/USD.yaml',
+		['code: USD', 'rates:', '  - rateInUSD: 1', '    validFrom: 2025-01-01'].join('\n')
+	)
+	await writeModel('eval-a')
+
+	expectSyncSuccess(env.runSync(['currencies', 'providers']))
+
+	const modelVersionsAfterFirstSync = await env.db.select().from(schema.modelVersions)
+	assert.strictEqual(modelVersionsAfterFirstSync.length, 2)
+	assert.strictEqual(modelVersionsAfterFirstSync.filter(version => version.active).length, 2)
+	const candidateVersion = modelVersionsAfterFirstSync.find(version => version.runtimeOptionsJson.includes('"user":"candidate"'))
+	const firstEvaluatorVersion = modelVersionsAfterFirstSync.find(version => version.runtimeOptionsJson.includes('"lane":"eval-a"'))
+	assert.ok(candidateVersion)
+	assert.ok(firstEvaluatorVersion)
+
+	await writeModel('eval-b')
+	expectSyncSuccess(env.runSync(['providers']))
+
+	const modelVersionsAfterSecondSync = await env.db.select().from(schema.modelVersions)
+	assert.strictEqual(modelVersionsAfterSecondSync.length, 3)
+	const activeVersions = modelVersionsAfterSecondSync.filter(version => version.active)
+	assert.strictEqual(activeVersions.length, 2)
+	assert.strictEqual(activeVersions.find(version => version.runtimeOptionsJson.includes('"user":"candidate"'))?.id, candidateVersion.id)
+	assert.strictEqual(modelVersionsAfterSecondSync.find(version => version.id === firstEvaluatorVersion.id)?.active, false)
+	assert.ok(activeVersions.some(version => version.runtimeOptionsJson.includes('"lane":"eval-b"')))
+})
+
 test('provider sync deactivates registry rows when files are removed', async t => {
 	const env = await createSyncTestEnv()
 	t.after(async () => {
@@ -341,7 +507,7 @@ test('currency sync updates and cleans up existing rate rows as YAML changes', a
 	assert.strictEqual(jpyRates.length, 0)
 })
 
-test('provider sync rejects conflicting active model variants for the same provider/model code', async t => {
+test('provider sync rejects active model variants without declared unique properties', async t => {
 	const env = await createSyncTestEnv()
 	t.after(async () => {
 		await env.cleanup()
@@ -351,6 +517,7 @@ test('provider sync rejects conflicting active model variants for the same provi
 	await env.write(
 		'data/models/variant-a.yaml',
 		[
+			'id: openai/gpt-4o-mini-2024-07-18/a',
 			'code: gpt-4o-mini-a',
 			'provider: openai',
 			'providerModelCode: gpt-4o-mini-2024-07-18',
@@ -367,6 +534,7 @@ test('provider sync rejects conflicting active model variants for the same provi
 	await env.write(
 		'data/models/variant-b.yaml',
 		[
+			'id: openai/gpt-4o-mini-2024-07-18/b',
 			'code: gpt-4o-mini-b',
 			'provider: openai',
 			'providerModelCode: gpt-4o-mini-2024-07-18',
@@ -385,7 +553,7 @@ test('provider sync rejects conflicting active model variants for the same provi
 		['code: USD', 'rates:', '  - rateInUSD: 1', '    validFrom: 2025-01-01'].join('\n')
 	)
 
-	expectSyncFailure(env.runSync(['currencies', 'providers']), /Conflicting active model variants/)
+	expectSyncFailure(env.runSync(['currencies', 'providers']), /must declare uniqueProperties/)
 })
 
 test('prompt sync creates versions from replacements and updates active tags on resync', async t => {

--- a/tests/helpers/module-runner.ts
+++ b/tests/helpers/module-runner.ts
@@ -61,7 +61,9 @@ const operationMap = {
 			providers: registry.providers,
 			models: registry.models,
 			activeModels: registry.activeModels,
-			modelReferences: Array.from(registry.modelsByReference.keys()),
+			modelReferences: Array.from(
+				new Set(registry.activeModels.map(model => `${model.provider}:${model.providerModelCode}`))
+			),
 		}
 	},
 	'currencyRegistry:loadDefinitions': async () => (await import('../../src/config/currency-registry.js')).loadCurrencyDefinitions(),

--- a/tests/helpers/test-harness.ts
+++ b/tests/helpers/test-harness.ts
@@ -9,6 +9,7 @@ import { sql } from 'drizzle-orm'
 
 import { schema } from '../../src/database/schema.js'
 import { EMPTY_MODEL_RUNTIME_OPTIONS_JSON } from '../../src/utils/json.js'
+import { getModelRuntimeIdentityKeys } from '../../src/config/model-registry.js'
 
 const repoRoot = process.cwd()
 const migrationsDir = path.join(repoRoot, 'migrations')
@@ -226,14 +227,29 @@ export const createSyncTestEnv = async () => {
 	}
 }
 
-export const createRegistry = (...models: Array<{ provider: string; providerModelCode: string; [key: string]: unknown }>) =>
-	({
+export const createRegistry = (
+	...models: Array<{ id?: string; provider: string; providerModelCode: string; [key: string]: unknown }>
+) => {
+	const modelsWithIds = models.map(model => ({
+		...model,
+		id: model.id ?? `${model.provider}/${model.providerModelCode}`,
+		providerOptions: model.providerOptions ?? {},
+		thinking: model.thinking,
+		candidateOverrides: model.candidateOverrides,
+		evaluatorOverrides: model.evaluatorOverrides,
+	}))
+
+	return {
 		providers: [],
 		providersByCode: new Map(),
-		models: models as never[],
-		activeModels: models as never[],
-		modelsByReference: new Map(models.map(model => [`${model.provider}:${model.providerModelCode}`, model])),
-	}) as const
+		models: modelsWithIds as never[],
+		activeModels: modelsWithIds as never[],
+		modelsById: new Map(modelsWithIds.map(model => [model.id, model])),
+		modelsByRuntimeIdentity: new Map(
+			modelsWithIds.flatMap(model => getModelRuntimeIdentityKeys(model).map(key => [key, model] as const))
+		),
+	} as const
+}
 
 export const insertProviderModel = async (
 	db: ReturnType<typeof drizzle>,

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -16,13 +16,13 @@ import {
 } from './helpers/test-harness.js'
 
 const baseTestsConfig = (provider: string, model: string) => ({
-	candidates: [{ provider, model }],
+	candidates: [{ id: `${provider}/${model}` }],
 	candidatesTemperature: 0.3,
 	attempts: 1,
 	requiredTags1: [] as string[],
 	requiredTags2: [] as string[],
 	prohibitedTags: [] as string[],
-	evaluators: [] as Array<{ provider: string; model: string }>,
+	evaluators: [] as Array<{ id: string }>,
 	evaluatorsTemperature: 0.4,
 	evaluationsPerEvaluator: 1,
 	analysisQueries: undefined,

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -24,6 +24,35 @@ const expectModuleSuccess = (result: { status: number | null; stdout: string; st
 	}
 }
 
+const writeStatsModelRegistry = async (env: Awaited<ReturnType<typeof createSyncTestEnv>>) => {
+	await env.write(
+		'data/providers/candidate-provider.yaml',
+		['code: candidate-provider', 'name: Candidate provider', 'type: openai'].join('\n')
+	)
+	await env.write(
+		'data/providers/evaluator-provider.yaml',
+		['code: evaluator-provider', 'name: Evaluator provider', 'type: openai'].join('\n')
+	)
+	await env.write(
+		'data/models/candidate-model.yaml',
+		[
+			'code: candidate-model',
+			'provider: candidate-provider',
+			'providerModelCode: candidate-model',
+			'costs: []',
+		].join('\n')
+	)
+	await env.write(
+		'data/models/evaluator-model.yaml',
+		[
+			'code: evaluator-model',
+			'provider: evaluator-provider',
+			'providerModelCode: evaluator-model',
+			'costs: []',
+		].join('\n')
+	)
+}
+
 test('showStats warns when the query has no active candidate models', async t => {
 	const env = await createSyncTestEnv()
 	t.after(async () => {
@@ -61,6 +90,7 @@ test('showStats aggregates filtered sessions, evaluations, and converted costs',
 		modelCode: 'evaluator-model',
 		providerModelCode: 'evaluator-model',
 	})
+	await writeStatsModelRegistry(env)
 	const { promptVersion: candidatePromptVersion } = await insertPromptVersion(env.db, {
 		code: 'candidate-prompt',
 		content: 'Answer briefly.',
@@ -225,15 +255,13 @@ test('showStats aggregates filtered sessions, evaluations, and converted costs',
 			evaluatorsTemperature: 0.4,
 			candidates: [
 				{
-					provider: 'candidate-provider',
-					model: 'candidate-model',
+					id: 'candidate-provider/candidate-model',
 					temperature: 0.3,
 				},
 			],
 			evaluators: [
 				{
-					provider: 'evaluator-provider',
-					model: 'evaluator-model',
+					id: 'evaluator-provider/evaluator-model',
 					temperature: 0.4,
 				},
 			],
@@ -244,7 +272,7 @@ test('showStats aggregates filtered sessions, evaluations, and converted costs',
 	assert.strictEqual(output.tables.length, 1)
 
 	const table = output.tables[0]?.[0] as Record<string, Record<string, string | number>>
-	assert.deepStrictEqual(table['candidate-model'], {
+	assert.deepStrictEqual(table['candidate-provider/candidate-model'], {
 		Provider: 'candidate-provider',
 		'✅%': 100,
 		'sess.': 1,
@@ -271,6 +299,7 @@ test('showStats filters sessions by candidate system prompt code or version hash
 		modelCode: 'evaluator-model',
 		providerModelCode: 'evaluator-model',
 	})
+	await writeStatsModelRegistry(env)
 	const { prompt: helpfulPrompt, promptVersion: helpfulPromptVersion1 } = await insertPromptVersion(env.db, {
 		code: 'helpful',
 		content: 'Answer helpfully.',
@@ -416,20 +445,18 @@ test('showStats filters sessions by candidate system prompt code or version hash
 				systemPrompts,
 				candidates: [
 					{
-						provider: 'candidate-provider',
-						model: 'candidate-model',
+						id: 'candidate-provider/candidate-model',
 					},
 				],
 				evaluators: [
 					{
-						provider: 'evaluator-provider',
-						model: 'evaluator-model',
+						id: 'evaluator-provider/evaluator-model',
 					},
 				],
 			})
 		).tables[0]?.[0] as Record<string, Record<string, string | number>>
 
-	assert.deepStrictEqual(runPromptQuery(['helpful'])['candidate-model'], {
+	assert.deepStrictEqual(runPromptQuery(['helpful'])['candidate-provider/candidate-model'], {
 		Provider: 'candidate-provider',
 		'✅%': 50,
 		'sess.': 2,
@@ -438,7 +465,7 @@ test('showStats filters sessions by candidate system prompt code or version hash
 		'💰/💯sess.': '$100.00',
 		'Tot.💰': '$2.00',
 	})
-	assert.deepStrictEqual(runPromptQuery(['helpful-v2-hash'])['candidate-model'], {
+	assert.deepStrictEqual(runPromptQuery(['helpful-v2-hash'])['candidate-provider/candidate-model'], {
 		Provider: 'candidate-provider',
 		'✅%': 0,
 		'sess.': 1,
@@ -447,7 +474,7 @@ test('showStats filters sessions by candidate system prompt code or version hash
 		'💰/💯sess.': '$100.00',
 		'Tot.💰': '$1.00',
 	})
-	assert.deepStrictEqual(runPromptQuery(['helpful-v1-hash', 'concise'])['candidate-model'], {
+	assert.deepStrictEqual(runPromptQuery(['helpful-v1-hash', 'concise'])['candidate-provider/candidate-model'], {
 		Provider: 'candidate-provider',
 		'✅%': 100,
 		'sess.': 2,


### PR DESCRIPTION
## Summary

- target configured models by stable model definition `id`
- allow multiple active YAML definitions for the same provider model when `uniqueProperties` distinguish them
- keep DB model-version identity tied to runtime options so adding only an `id` does not create unnecessary reruns
- update docs, examples, generated `dist`, and test coverage for the id-based workflow

## Validation

- `npm run compile`
- `npm test` (113 passing)

## Review

- self-reviewed the diff
- two sub-agent reviewers checked spec conformance, runtime query behavior, DB sync identity, docs, and tests; no issues found

Closes #10
